### PR TITLE
feat(fastapi_profiler): 添加内存分析中间件支持 tracemalloc 和 memray

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,4 +6,6 @@ per-file-ignores =
     fastapi_profiler/dashboard.py:E501
     fastapi_profiler/stats.py:E501
     fastapi_profiler/profiler.py:E501
+    fastapi_profiler/memory_dashboard.py:E501
+    fastapi_profiler/memory_middleware.py:E501
     test/*.py:E501

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,169 @@
+name: Release to PyPI
+
+# Triggered when a version tag is pushed, e.g. `git push origin v1.6.0`.
+# Set the PyPI token as a repository secret named `PYPI_API_TOKEN`.
+on:
+  push:
+    tags:
+      - "v*"
+
+# Concurrency guard: never publish two tags in parallel.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # required to create a GitHub Release
+
+jobs:
+  # ------------------------------------------------------------------
+  # 1. Sanity check: lint + typecheck + tests on a single matrix entry.
+  #    The full multi-OS / multi-Python matrix already runs on every push
+  #    in `python-app.yml`; this job only re-validates the *exact tagged
+  #    commit* before we publish anything to PyPI.
+  # ------------------------------------------------------------------
+  verify:
+    name: Verify tagged commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Lint, type check and test
+        run: make check
+
+      - name: Verify tag matches package version
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(uv run python -c 'from fastapi_profiler import __version__; print(__version__)')"
+          echo "tag    version: ${TAG_VERSION}"
+          echo "package version: ${PKG_VERSION}"
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match package version ${PKG_VERSION}"
+            exit 1
+          fi
+
+  # ------------------------------------------------------------------
+  # 2. Build sdist + wheel and upload them as workflow artifacts so they
+  #    can be reused by the publish step and inspected from the run page.
+  # ------------------------------------------------------------------
+  build:
+    name: Build distributions
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: List built artifacts
+        run: ls -lh dist/
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 14
+
+  # ------------------------------------------------------------------
+  # 3. Publish to PyPI using the user-managed token in GitHub secrets.
+  # ------------------------------------------------------------------
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi   # optional: protect the secret behind a GitHub environment
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: false
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          # `uv publish` reads UV_PUBLISH_TOKEN automatically when it is
+          # set; `__token__` is the conventional username for PyPI tokens
+          # but is unused when a token is supplied via env var.
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish dist/*
+
+  # ------------------------------------------------------------------
+  # 4. Create a GitHub Release with the matching CHANGELOG section as
+  #    the release body, and attach the built artifacts.
+  # ------------------------------------------------------------------
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          # Slice the section "### version X.Y.Z" up to (but excluding)
+          # the next "### version " heading.  Falls back to a generic
+          # message when the section cannot be located.
+          NOTES_FILE="$(mktemp)"
+          awk -v ver="### version ${TAG_VERSION}" '
+            $0 == ver { capture=1; next }
+            capture && /^### version / { exit }
+            capture { print }
+          ' CHANGELOG.md > "${NOTES_FILE}"
+          if [ ! -s "${NOTES_FILE}" ]; then
+            echo "Release ${GITHUB_REF_NAME}." > "${NOTES_FILE}"
+          fi
+          {
+            echo "notes_file=${NOTES_FILE}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "----- release notes preview -----"
+          cat "${NOTES_FILE}"
+          echo "---------------------------------"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: ${{ steps.notes.outputs.notes_file }}
+          files: dist/*
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # ChangeLog
 
+### version 1.6.0
+  * **Memory profiler middleware** (`MemoryProfilerMiddleware`): a new,
+    independent ASGI middleware that exposes an HTTP control plane for
+    memory analysis.  Mounted at `/__memory_profiler__` by default.
+  * **`tracemalloc` integration** (standard library, zero extra deps):
+    drive the full lifecycle over HTTP — `start`, `stop`, `snapshot`,
+    `compare`, `snapshots` (list), `status`.  Snapshots are persisted as
+    `.snap` files under a configurable `snapshot_dir`.
+    - `autostart_tracemalloc=True` begins tracing during middleware
+      construction so allocations made at application startup are
+      captured as well.
+    - Configurable frame depth (`tracemalloc_frames`, default 25) and
+      top-N size (`tracemalloc_top`, default 20).
+  * **`memray` integration** (optional dependency, Linux/macOS only):
+    drive `memray.Tracker` start/stop via HTTP and obtain a `.bin`
+    capture file ready to be rendered by the official `memray flamegraph`
+    / `memray tree` / `memray stats` CLIs.  Supports `native_traces`,
+    `follow_fork`, and `trace_python_allocators` flags.
+    - Install with `pip install 'fastapi_profiler[memray]'`.
+    - Returns a structured `503 Service Unavailable` (with reason and
+      import error) on platforms where memray is missing or unsupported.
+  * **Graceful shutdown handling**: any active memray session is
+    finalised automatically on application shutdown so the `.bin` file
+    is never left half-written.
+  * **No built-in authentication** — the dashboard mount path is not
+    protected on purpose; secure it via reverse-proxy ACLs or by setting
+    `filter_paths` on other middlewares.  The new
+    `fastapi_memory_custom_path_example.py` documents recommended
+    deployment patterns.
+  * **New public exports**: `MemoryProfilerMiddleware`,
+    `TracemallocProfiler`, `MemrayProfiler`, `MEMRAY_AVAILABLE`.
+  * **Examples** (under `example/`):
+    - `fastapi_memory_profiler_example.py` — multi-scenario allocation
+      routes (`/alloc/small`, `/alloc/big`, `/alloc/leak`,
+      `/alloc/clear`, `/alloc/stats`).
+    - `fastapi_memory_tracemalloc_client_example.py` — stdlib-only
+      driver that walks the full tracemalloc lifecycle and prints all
+      `.snap` files on disk.
+    - `fastapi_memory_memray_client_example.py` — stdlib-only driver
+      for the memray lifecycle that prints the resulting `.bin` path
+      and the matching `memray flamegraph/tree/stats` commands.
+    - `fastapi_cpu_and_memory_profiler_example.py` — CPU + memory
+      profilers running side-by-side with `filter_paths` isolation.
+    - `fastapi_memory_autostart_example.py` — capture allocations made
+      during application startup via `autostart_tracemalloc=True`.
+    - `fastapi_memory_custom_path_example.py` — custom dashboard path
+      and reverse-proxy protection guidance.
+  * **Tests**: `test/test_memory.py` and `test/test_memory_coverage.py`
+    bring the memory subsystem to ~99% line coverage, including
+    Windows/unavailable branches, tracker rollback on start failure,
+    and full HTTP routing through the dashboard.
+
 ### version 1.5.0
   * **Sampling rate** (`profiler_sample_rate`): profile only a configurable
     fraction of requests (0.0–1.0) to reduce overhead in production.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ All parameters are passed as keyword arguments to `add_middleware()`.
 | `dashboard_path` | `str` | `"/__profiler__"` | URL prefix for the dashboard. Only used when `enable_dashboard=True`. |
 | `enabled` | `bool` | `True` | Master switch. When `False`, the middleware passes all requests through without profiling. Controllable at runtime via the `/config` API. |
 
+### Memory Profiler Parameters (`MemoryProfilerMiddleware`)
+
+The memory profiler is a **separate middleware** that runs alongside the CPU profiler.  It exposes an HTTP control plane to drive `tracemalloc` (always available) and `memray` (optional native allocator tracker).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `server_app` | `FastAPI \| None` | `None` | Required to mount the control router and register a shutdown hook that finalises any running memray session. |
+| `memory_dashboard_path` | `str` | `"/__memory_profiler__"` | URL prefix where the memory profiler endpoints are mounted. |
+| `snapshot_dir` | `str` | `"./mem-snapshots"` | Directory used for both tracemalloc `.snap` files and memray `.bin` files. Created on demand. |
+| `tracemalloc_frames` | `int` | `25` | Default frame depth passed to `tracemalloc.start` when no explicit `frames` is supplied via HTTP. |
+| `tracemalloc_top` | `int` | `20` | Default top-N size for `snapshot` / `compare` JSON responses. |
+| `autostart_tracemalloc` | `bool` | `False` | Start `tracemalloc` during middleware construction so allocations from app startup are also captured. |
+
 ## 🚀 Usage Examples
 
 ### Basic — print profile to stdout
@@ -278,6 +291,77 @@ app.add_middleware(
 )
 ```
 
+### Memory profiling — tracemalloc + memray via HTTP
+
+Mount `MemoryProfilerMiddleware` to expose a control plane that lets you start/stop `tracemalloc` and `memray` at runtime and dump snapshots to disk:
+
+```python
+from fastapi import FastAPI
+from fastapi_profiler import MemoryProfilerMiddleware, PyInstrumentProfilerMiddleware
+
+app = FastAPI()
+# CPU profiler (existing)
+app.add_middleware(
+    PyInstrumentProfilerMiddleware,
+    server_app=app,
+    enable_dashboard=True,
+    filter_paths=["/__profiler__", "/__memory_profiler__"],
+)
+# Memory profiler (new, independent)
+app.add_middleware(
+    MemoryProfilerMiddleware,
+    server_app=app,
+    snapshot_dir="./mem-snapshots",
+    autostart_tracemalloc=False,
+)
+```
+
+Drive it with `curl`:
+
+```shell
+# tracemalloc — Python-level allocations, always available
+curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/start \
+     -H "Content-Type: application/json" -d '{"frames": 25}'
+curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/snapshot \
+     -H "Content-Type: application/json" -d '{"top": 20}'
+# ...exercise traffic...
+curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/snapshot
+curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/compare \
+     -H "Content-Type: application/json" -d '{"top": 20}'
+curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/stop
+
+# memray — native + Python allocations, dumps a .bin file
+# Install with:  pip install 'fastapi_profiler[memray]'   (Linux/macOS only)
+curl -XPOST localhost:8080/__memory_profiler__/memray/start \
+     -H "Content-Type: application/json" -d '{"native": true}'
+# ...exercise traffic...
+curl -XPOST localhost:8080/__memory_profiler__/memray/stop
+# → render the resulting .bin with the memray CLI:
+memray flamegraph ./mem-snapshots/memray-<id>.bin
+memray tree       ./mem-snapshots/memray-<id>.bin
+memray stats      ./mem-snapshots/memray-<id>.bin
+```
+
+#### Memory Profiler API endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`  | `/__memory_profiler__/` | HTML index with usage hints |
+| `GET`  | `/__memory_profiler__/status` | Combined status of both profilers |
+| `GET`  | `/__memory_profiler__/tracemalloc/status` | tracemalloc state (running, frames, traced memory) |
+| `POST` | `/__memory_profiler__/tracemalloc/start` | Body: `{"frames": int?}` |
+| `POST` | `/__memory_profiler__/tracemalloc/stop` | Stop and clear in-memory snapshots |
+| `POST` | `/__memory_profiler__/tracemalloc/snapshot` | Body: `{"top": int?}` — dumps a `.snap` file and returns top-N stats |
+| `POST` | `/__memory_profiler__/tracemalloc/compare` | Body: `{"top": int?, "snapshot_a": str?, "snapshot_b": str?}` — defaults to last two snapshots |
+| `GET`  | `/__memory_profiler__/tracemalloc/snapshots` | List captured snapshot ids and file paths |
+| `GET`  | `/__memory_profiler__/memray/status` | memray availability + current session |
+| `POST` | `/__memory_profiler__/memray/start` | Body: `{"output_path": str?, "native": bool?, "follow_fork": bool?, "trace_python_allocators": bool?}` |
+| `POST` | `/__memory_profiler__/memray/stop` | Finalise the `.bin` capture file |
+
+> **Security note:** the memory profiler endpoints **do not authenticate requests** and can dump heap traces of your process. Protect the path with a reverse proxy ACL, network policy, or by setting `filter_paths=["/__memory_profiler__"]` on any other middleware that might expose it externally.
+
+> **memray availability:** the `memray` extra is a soft dependency. When it is missing or you are on Windows, `/memray/start` returns `503` with a clear `availability` payload; `/memray/status` always works. Install with `pip install 'fastapi_profiler[memray]'`.
+
 ## 📂 Example Files
 
 | File | Description |
@@ -294,6 +378,7 @@ app.add_middleware(
 | [`fastapi_per_route_history_example.py`](example/fastapi_per_route_history_example.py) | Per-route profile history |
 | [`fastapi_runtime_toggle_example.py`](example/fastapi_runtime_toggle_example.py) | Runtime enable/disable |
 | [`fastapi_full_features_example.py`](example/fastapi_full_features_example.py) | All features combined |
+| [`fastapi_memory_profiler_example.py`](example/fastapi_memory_profiler_example.py) | Memory profiler (tracemalloc + memray) via HTTP control plane |
 
 ## ⛏ Development
 

--- a/example/fastapi_always_profile_errors_example.py
+++ b/example/fastapi_always_profile_errors_example.py
@@ -7,8 +7,8 @@ This is useful for diagnosing performance regressions that only appear
 under error conditions.
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 

--- a/example/fastapi_cpu_and_memory_profiler_example.py
+++ b/example/fastapi_cpu_and_memory_profiler_example.py
@@ -1,0 +1,109 @@
+"""Run CPU and memory profilers side-by-side in the same FastAPI app.
+
+This pattern is what you typically want in production-like environments:
+
+- ``PyInstrumentProfilerMiddleware`` records *per-request* CPU/wall-time
+  profiles (sampling-based, low overhead).
+- ``MemoryProfilerMiddleware`` exposes an HTTP control plane to drive
+  ``tracemalloc`` and ``memray`` *process-globally* on demand.
+
+Both middlewares mount their own dashboards on independent paths and
+ignore each other thanks to ``filter_paths``:
+
+- CPU dashboard    : ``/__profiler__``
+- Memory dashboard : ``/__memory_profiler__``
+
+Usage::
+
+    uv run python example/fastapi_cpu_and_memory_profiler_example.py
+
+    # CPU dashboard (HTML UI)
+    open http://localhost:8080/__profiler__
+
+    # Memory control plane (JSON API)
+    curl http://localhost:8080/__memory_profiler__/status
+"""
+
+import os
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from fastapi_profiler import (
+    MemoryProfilerMiddleware,
+    PyInstrumentProfilerMiddleware,
+)
+
+CPU_DASHBOARD = "/__profiler__"
+MEMORY_DASHBOARD = "/__memory_profiler__"
+
+app = FastAPI()
+
+# Memory profiler — mount first so its router is registered before the
+# CPU middleware wraps the ASGI stack.  Order does not affect correctness
+# (the memory dashboard is mounted on the host app), but keeping it first
+# makes the intent explicit.
+app.add_middleware(
+    MemoryProfilerMiddleware,
+    server_app=app,
+    memory_dashboard_path=MEMORY_DASHBOARD,
+    snapshot_dir="./mem-snapshots",
+    autostart_tracemalloc=False,
+)
+
+# CPU/wall-time profiler.  ``filter_paths`` excludes both dashboards so
+# their internal traffic never appears in the per-route CPU stats.
+app.add_middleware(
+    PyInstrumentProfilerMiddleware,
+    server_app=app,
+    enable_dashboard=True,
+    dashboard_path=CPU_DASHBOARD,
+    profiler_sample_rate=1.0,
+    slow_request_threshold_ms=0,
+    is_print_each_request=True,
+    filter_paths=[CPU_DASHBOARD, MEMORY_DASHBOARD],
+    enabled=True,
+)
+
+_LEAK_BUCKET: list = []
+
+
+@app.get("/test")
+async def normal_request():
+    return JSONResponse({"retMsg": "Hello World!"})
+
+
+@app.get("/cpu/heavy")
+async def cpu_heavy():
+    """Spend ~50 ms of CPU so PyInstrument has something to show."""
+    total = 0
+    for i in range(200_000):
+        total += i * i
+    return JSONResponse({"retMsg": "cpu work done", "checksum": total % 9973})
+
+
+@app.get("/alloc/leak")
+async def alloc_leak():
+    """Accumulate ~640 KB per call so memory profilers have something to show."""
+    _LEAK_BUCKET.append(["x" * 64 for _ in range(10000)])
+    return JSONResponse({
+        "retMsg": "leak step recorded",
+        "leak_bucket_size": len(_LEAK_BUCKET),
+    })
+
+
+@app.post("/alloc/clear")
+async def alloc_clear():
+    dropped = len(_LEAK_BUCKET)
+    _LEAK_BUCKET.clear()
+    return JSONResponse({"retMsg": "cleared", "dropped": dropped})
+
+
+# Or you can use the console with command "uvicorn" to run this example.
+# Command:
+#   uvicorn fastapi_cpu_and_memory_profiler_example:app \
+#       --host=0.0.0.0 --port=8080
+if __name__ == "__main__":
+    app_name = os.path.basename(__file__).replace(".py", "")
+    uvicorn.run(app=f"{app_name}:app", host="0.0.0.0", port=8080, workers=1)

--- a/example/fastapi_example.py
+++ b/example/fastapi_example.py
@@ -1,11 +1,10 @@
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from fastapi_profiler import PyInstrumentProfilerMiddleware
-
 
 app = FastAPI()
 app.add_middleware(PyInstrumentProfilerMiddleware)

--- a/example/fastapi_full_features_example.py
+++ b/example/fastapi_full_features_example.py
@@ -15,8 +15,8 @@ After starting the server, visit:
 """
 import logging
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 

--- a/example/fastapi_json_logging_example.py
+++ b/example/fastapi_json_logging_example.py
@@ -12,8 +12,8 @@ Example log output:
 """
 import logging
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 

--- a/example/fastapi_memory_autostart_example.py
+++ b/example/fastapi_memory_autostart_example.py
@@ -1,0 +1,83 @@
+"""Auto-start tracemalloc as soon as the middleware is constructed.
+
+Set ``autostart_tracemalloc=True`` to begin tracing during application
+startup *before* any request is served.  This is invaluable when you
+suspect a leak that happens during application boot (model loading,
+warmup caches, framework initialisation, …).
+
+The HTTP control plane stays available, so you can still call
+``/tracemalloc/snapshot`` / ``/tracemalloc/stop`` later to inspect or
+turn it off.
+
+Usage::
+
+    uv run python example/fastapi_memory_autostart_example.py
+
+    # Right after startup — already tracing!
+    curl http://localhost:8080/__memory_profiler__/tracemalloc/status
+
+    # Capture a baseline snapshot
+    curl -XPOST http://localhost:8080/__memory_profiler__/tracemalloc/snapshot
+
+    # Drive the workload
+    curl http://localhost:8080/alloc/leak
+    curl http://localhost:8080/alloc/leak
+
+    # Diff against the baseline
+    curl -XPOST http://localhost:8080/__memory_profiler__/tracemalloc/snapshot
+    curl -XPOST http://localhost:8080/__memory_profiler__/tracemalloc/compare
+"""
+
+import os
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from fastapi_profiler import MemoryProfilerMiddleware
+
+# Allocate something during *module import* — autostart_tracemalloc
+# guarantees this allocation is recorded.
+_STARTUP_CACHE = [bytearray(1024 * 1024) for _ in range(2)]  # ~2 MB
+
+app = FastAPI()
+app.add_middleware(
+    MemoryProfilerMiddleware,
+    server_app=app,
+    snapshot_dir="./mem-snapshots",
+    autostart_tracemalloc=True,   # ← tracemalloc.start() runs immediately
+    tracemalloc_frames=30,        # deeper tracebacks for startup analysis
+)
+
+_LEAK_BUCKET: list = []
+
+
+@app.on_event("startup")
+async def warmup() -> None:
+    """Simulate a startup hook that allocates more memory."""
+    _STARTUP_CACHE.append(bytearray(512 * 1024))
+
+
+@app.get("/alloc/leak")
+async def alloc_leak():
+    _LEAK_BUCKET.append(["x" * 64 for _ in range(10000)])
+    return JSONResponse({
+        "retMsg": "leak step recorded",
+        "leak_bucket_size": len(_LEAK_BUCKET),
+    })
+
+
+@app.get("/startup/cache")
+async def startup_cache():
+    return JSONResponse({
+        "items": len(_STARTUP_CACHE),
+        "approx_bytes": sum(len(b) for b in _STARTUP_CACHE),
+    })
+
+
+# Or you can use the console with command "uvicorn" to run this example.
+# Command:
+#   uvicorn fastapi_memory_autostart_example:app --host=0.0.0.0 --port=8080
+if __name__ == "__main__":
+    app_name = os.path.basename(__file__).replace(".py", "")
+    uvicorn.run(app=f"{app_name}:app", host="0.0.0.0", port=8080, workers=1)

--- a/example/fastapi_memory_custom_path_example.py
+++ b/example/fastapi_memory_custom_path_example.py
@@ -1,0 +1,110 @@
+"""Customise the memory dashboard path and discuss access protection.
+
+The default mount path is ``/__memory_profiler__``.  In real deployments
+you typically want either a hard-to-guess path or to gate access at the
+reverse-proxy layer — the middleware itself ships **without** built-in
+authentication on purpose, to keep its footprint tiny and to avoid
+imposing an opinion on auth backends.
+
+This example shows three things:
+
+1. Mounting the memory dashboard on a custom prefix
+   (``/_internal/mem-debug``).
+2. Persisting captures to a non-default directory.
+3. Combining with ``PyInstrumentProfilerMiddleware`` and using
+   ``filter_paths`` to keep the memory dashboard out of CPU stats.
+
+Recommended deployment patterns
+-------------------------------
+- **Bind to localhost only** when running behind a reverse proxy and
+  let the proxy expose only the public routes.
+- **Block the dashboard prefix at the proxy layer** (nginx ``location``
+  / ALB rule) for everyone except a trusted CIDR, e.g.::
+
+      location /_internal/ {
+          allow 10.0.0.0/8;
+          deny  all;
+          proxy_pass http://app;
+      }
+
+- **Add an auth dependency in front of the mount** by wrapping
+  ``MemoryProfilerMiddleware`` behind your own router/middleware that
+  enforces a shared secret header.
+
+Usage::
+
+    uv run python example/fastapi_memory_custom_path_example.py
+
+    curl http://localhost:8080/_internal/mem-debug/status
+    curl -XPOST http://localhost:8080/_internal/mem-debug/tracemalloc/start
+    curl http://localhost:8080/alloc/leak
+    curl -XPOST http://localhost:8080/_internal/mem-debug/tracemalloc/snapshot
+    curl -XPOST http://localhost:8080/_internal/mem-debug/tracemalloc/stop
+"""
+
+import os
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from fastapi_profiler import (
+    MemoryProfilerMiddleware,
+    PyInstrumentProfilerMiddleware,
+)
+
+CUSTOM_MEM_PATH = "/_internal/mem-debug"
+CUSTOM_SNAPSHOT_DIR = "./var/mem-snapshots"
+
+app = FastAPI()
+
+app.add_middleware(
+    MemoryProfilerMiddleware,
+    server_app=app,
+    memory_dashboard_path=CUSTOM_MEM_PATH,
+    snapshot_dir=CUSTOM_SNAPSHOT_DIR,
+    autostart_tracemalloc=False,
+)
+
+# Hide both dashboards from the CPU profiler stats.
+app.add_middleware(
+    PyInstrumentProfilerMiddleware,
+    server_app=app,
+    enable_dashboard=True,
+    dashboard_path="/__profiler__",
+    profiler_sample_rate=1.0,
+    is_print_each_request=False,
+    filter_paths=["/__profiler__", CUSTOM_MEM_PATH],
+    enabled=True,
+)
+
+_LEAK_BUCKET: list = []
+
+
+@app.get("/")
+async def index():
+    return JSONResponse({
+        "retMsg": "ok",
+        "memory_dashboard": CUSTOM_MEM_PATH,
+        "snapshot_dir": os.path.abspath(CUSTOM_SNAPSHOT_DIR),
+    })
+
+
+@app.get("/alloc/leak")
+async def alloc_leak():
+    _LEAK_BUCKET.append(["x" * 64 for _ in range(10000)])
+    return JSONResponse({
+        "retMsg": "leak step recorded",
+        "leak_bucket_size": len(_LEAK_BUCKET),
+    })
+
+
+# Or you can use the console with command "uvicorn" to run this example.
+# Command:
+#   uvicorn fastapi_memory_custom_path_example:app \
+#       --host=127.0.0.1 --port=8080
+if __name__ == "__main__":
+    app_name = os.path.basename(__file__).replace(".py", "")
+    # Bind to localhost-only by default — pair with a reverse proxy
+    # to expose only the public routes outside the host.
+    uvicorn.run(app=f"{app_name}:app", host="127.0.0.1", port=8080, workers=1)

--- a/example/fastapi_memory_memray_client_example.py
+++ b/example/fastapi_memory_memray_client_example.py
@@ -1,0 +1,139 @@
+"""End-to-end driver for the memray HTTP control plane.
+
+Run order::
+
+    # Terminal 1: server
+    uv run python example/fastapi_memory_profiler_example.py
+
+    # Terminal 2: this driver
+    uv run python example/fastapi_memory_memray_client_example.py
+
+The script walks through:
+
+    GET  /memray/status           ← confirm memray is available
+    POST /memray/start            ← begin a tracking session
+    GET  /alloc/leak  (×N)        ← generate real allocations
+    GET  /memray/status           ← inspect running session
+    POST /memray/stop             ← finalise the .bin capture file
+    (prints render commands you can copy/paste)
+
+Requires the optional dependency::
+
+    pip install 'fastapi_profiler[memray]'
+
+memray is unavailable on Windows.  In that case the script exits with a
+helpful message instead of failing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("FASTAPI_PROFILER_BASE", "http://127.0.0.1:8080")
+DASHBOARD = os.environ.get("FASTAPI_PROFILER_MEM_PATH", "/__memory_profiler__")
+MEMRAY_BASE = f"{BASE_URL}{DASHBOARD}/memray"
+ALLOC_URL = f"{BASE_URL}/alloc/leak"
+
+NATIVE = os.environ.get("FASTAPI_PROFILER_MEMRAY_NATIVE", "0") == "1"
+WORKLOAD = int(os.environ.get("FASTAPI_PROFILER_MEMRAY_WORKLOAD", "30"))
+
+
+def _request(method: str, url: str, payload: dict | None = None) -> dict:
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read().decode("utf-8")
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        # Surface the JSON error body from the dashboard so users understand
+        # *why* memray refused to start (e.g. unavailable, already running).
+        try:
+            return json.loads(exc.read().decode("utf-8"))
+        except Exception:
+            return {"error": str(exc), "status": exc.code}
+
+
+def section(title: str) -> None:
+    print()
+    print("=" * 72)
+    print(title)
+    print("=" * 72)
+
+
+def main() -> int:
+    print(f"[client] target base : {BASE_URL}")
+    print(f"[client] dashboard   : {DASHBOARD}")
+    print(f"[client] native      : {NATIVE}")
+    print(f"[client] workload    : {WORKLOAD} requests")
+
+    try:
+        status = _request("GET", f"{MEMRAY_BASE}/status")
+    except urllib.error.URLError as exc:
+        print(f"[client] cannot reach server: {exc}")
+        print("[client] start the server first: "
+              "`uv run python example/fastapi_memory_profiler_example.py`")
+        return 2
+
+    section("1. memray availability check")
+    print(json.dumps(status, indent=2))
+    if not status.get("available"):
+        print()
+        print("⚠️  memray is not available on this host. "
+              "Install it (Linux/macOS only):")
+        print("    pip install 'fastapi_profiler[memray]'")
+        return 0
+
+    section("2. start memray session")
+    start = _request(
+        "POST",
+        f"{MEMRAY_BASE}/start",
+        {"native": NATIVE, "follow_fork": False},
+    )
+    print(json.dumps(start, indent=2))
+    if not start.get("running"):
+        print("⚠️  failed to start memray; aborting.")
+        return 1
+    output_path = start["output_path"]
+
+    section(f"3. generate workload — {WORKLOAD} /alloc/leak calls")
+    for _ in range(WORKLOAD):
+        urllib.request.urlopen(ALLOC_URL, timeout=5).read()
+    print("done.")
+
+    section("4. inspect running session")
+    print(json.dumps(_request("GET", f"{MEMRAY_BASE}/status"), indent=2))
+
+    section("5. stop memray session")
+    stop = _request("POST", f"{MEMRAY_BASE}/stop")
+    print(json.dumps(stop, indent=2))
+
+    section("6. inspect the captured .bin file")
+    if output_path and os.path.isfile(output_path):
+        size = os.path.getsize(output_path)
+        print(f"  path   : {output_path}")
+        print(f"  size   : {size:,} bytes ({size / 1024:.1f} KB)")
+    else:
+        print(f"  path   : {output_path}  (file missing on this host — "
+              "client and server may live on different machines)")
+
+    print()
+    print("Render the capture with the memray CLI:")
+    print(f"  memray flamegraph {output_path}")
+    print(f"  memray tree       {output_path}")
+    print(f"  memray stats      {output_path}")
+    print()
+    print("✅ memray lifecycle finished.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/example/fastapi_memory_profiler_example.py
+++ b/example/fastapi_memory_profiler_example.py
@@ -1,0 +1,119 @@
+"""Example: drive tracemalloc and (optional) memray via HTTP control plane.
+
+This example provides several allocation scenarios to make profiler output
+meaningful:
+
+- ``GET /alloc/small``   — small per-request allocation (~64 KB)
+- ``GET /alloc/big``     — single large allocation (~10 MB)
+- ``GET /alloc/leak``    — accumulating allocations (simulated leak)
+- ``POST /alloc/clear``  — release everything to validate ``compare`` deltas
+- ``GET /alloc/stats``   — quick view of current bucket state
+
+Run the server::
+
+    uv run python example/fastapi_memory_profiler_example.py
+
+Then exercise the control plane::
+
+    # ── tracemalloc ────────────────────────────────────────────────
+    curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/start
+    curl -XGET  localhost:8080/alloc/leak                # generate growth
+    curl -XGET  localhost:8080/alloc/leak
+    curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/snapshot
+    curl -XGET  localhost:8080/alloc/leak
+    curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/snapshot
+    curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/compare
+    curl -XPOST localhost:8080/__memory_profiler__/tracemalloc/stop
+
+    # ── memray (requires `pip install fastapi_profiler[memray]`,
+    #            Linux/macOS only) ─────────────────────────────────
+    curl -XPOST localhost:8080/__memory_profiler__/memray/start \\
+         -H 'Content-Type: application/json' \\
+         -d '{"native": false}'
+    curl -XGET  localhost:8080/alloc/leak
+    curl -XPOST localhost:8080/__memory_profiler__/memray/stop
+    # → render the resulting .bin file with `memray flamegraph <path>`
+"""
+
+import os
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from fastapi_profiler import MemoryProfilerMiddleware
+
+app = FastAPI()
+app.add_middleware(
+    MemoryProfilerMiddleware,
+    server_app=app,
+    snapshot_dir="./mem-snapshots",
+    autostart_tracemalloc=False,
+)
+
+# In-memory buckets used to drive allocation patterns.
+_LEAK_BUCKET: list = []
+_BIG_BUCKET: list = []
+
+
+@app.get("/alloc/small")
+async def alloc_small():
+    """Allocate ~64 KB per call (1000 strings of 64 bytes)."""
+    payload = ["x" * 64 for _ in range(1000)]
+    return JSONResponse({
+        "retMsg": "small allocation done",
+        "approx_bytes": 64 * 1000,
+        "items": len(payload),
+    })
+
+
+@app.get("/alloc/big")
+async def alloc_big():
+    """Allocate ~10 MB in a single call and keep it referenced."""
+    chunk = bytearray(10 * 1024 * 1024)
+    _BIG_BUCKET.append(chunk)
+    return JSONResponse({
+        "retMsg": "big allocation done",
+        "approx_bytes": len(chunk),
+        "big_bucket_size": len(_BIG_BUCKET),
+    })
+
+
+@app.get("/alloc/leak")
+async def alloc_leak():
+    """Accumulate ~640 KB per call to simulate a slow leak."""
+    _LEAK_BUCKET.append(["x" * 64 for _ in range(10000)])
+    return JSONResponse({
+        "retMsg": "leak step recorded",
+        "leak_bucket_size": len(_LEAK_BUCKET),
+    })
+
+
+@app.post("/alloc/clear")
+async def alloc_clear():
+    """Drop both buckets so a follow-up ``compare`` shows the delta."""
+    leak_dropped = len(_LEAK_BUCKET)
+    big_dropped = len(_BIG_BUCKET)
+    _LEAK_BUCKET.clear()
+    _BIG_BUCKET.clear()
+    return JSONResponse({
+        "retMsg": "cleared",
+        "leak_dropped": leak_dropped,
+        "big_dropped": big_dropped,
+    })
+
+
+@app.get("/alloc/stats")
+async def alloc_stats():
+    return JSONResponse({
+        "leak_bucket_size": len(_LEAK_BUCKET),
+        "big_bucket_size": len(_BIG_BUCKET),
+    })
+
+
+# Or you can use the console with command "uvicorn" to run this example.
+# Command:
+#   uvicorn fastapi_memory_profiler_example:app --host=0.0.0.0 --port=8080
+if __name__ == "__main__":
+    app_name = os.path.basename(__file__).replace(".py", "")
+    uvicorn.run(app=f"{app_name}:app", host="0.0.0.0", port=8080, workers=1)

--- a/example/fastapi_memory_tracemalloc_client_example.py
+++ b/example/fastapi_memory_tracemalloc_client_example.py
@@ -1,0 +1,135 @@
+"""End-to-end driver for the tracemalloc HTTP control plane.
+
+This is a *client* script: it expects a running server that mounts
+:class:`fastapi_profiler.MemoryProfilerMiddleware` (e.g. start
+``example/fastapi_memory_profiler_example.py`` first), then walks through
+the full lifecycle:
+
+    /tracemalloc/start
+        ↓
+    a few /alloc/leak calls            ← grow the heap a bit
+        ↓
+    /tracemalloc/snapshot              ← snapshot A
+        ↓
+    a few more /alloc/leak calls       ← grow some more
+        ↓
+    /tracemalloc/snapshot              ← snapshot B
+        ↓
+    /tracemalloc/compare               ← print top growers
+        ↓
+    /tracemalloc/snapshots             ← list all .snap files on disk
+        ↓
+    /tracemalloc/stop
+
+It uses only the standard library (urllib + json) so it runs anywhere
+without extra dependencies.
+
+Usage::
+
+    # Terminal 1: start the server
+    uv run python example/fastapi_memory_profiler_example.py
+
+    # Terminal 2: drive it
+    uv run python example/fastapi_memory_tracemalloc_client_example.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("FASTAPI_PROFILER_BASE", "http://127.0.0.1:8080")
+DASHBOARD = os.environ.get("FASTAPI_PROFILER_MEM_PATH", "/__memory_profiler__")
+TRACEMALLOC_BASE = f"{BASE_URL}{DASHBOARD}/tracemalloc"
+ALLOC_URL = f"{BASE_URL}/alloc/leak"
+
+
+def _request(method: str, url: str, payload: dict | None = None) -> dict:
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        body = resp.read().decode("utf-8")
+        if not body:
+            return {}
+        return json.loads(body)
+
+
+def section(title: str) -> None:
+    print()
+    print("=" * 72)
+    print(title)
+    print("=" * 72)
+
+
+def drive_workload(times: int) -> None:
+    for _ in range(times):
+        _request("GET", ALLOC_URL)
+
+
+def main() -> int:
+    print(f"[client] target base : {BASE_URL}")
+    print(f"[client] dashboard   : {DASHBOARD}")
+
+    try:
+        _request("GET", f"{TRACEMALLOC_BASE}/status")
+    except urllib.error.URLError as exc:
+        print(f"[client] cannot reach server: {exc}")
+        print("[client] start the server first: "
+              "`uv run python example/fastapi_memory_profiler_example.py`")
+        return 2
+
+    section("1. start tracemalloc (frames=25)")
+    print(json.dumps(
+        _request("POST", f"{TRACEMALLOC_BASE}/start", {"frames": 25}),
+        indent=2,
+    ))
+
+    section("2. workload round 1 — 5 leak calls")
+    drive_workload(5)
+    print("done.")
+
+    section("3. snapshot A")
+    snap_a = _request("POST", f"{TRACEMALLOC_BASE}/snapshot", {"top": 10})
+    print(json.dumps(snap_a, indent=2))
+
+    section("4. workload round 2 — 10 leak calls")
+    drive_workload(10)
+    print("done.")
+    # Give tracemalloc a tick to register the latest allocations.
+    time.sleep(0.05)
+
+    section("5. snapshot B")
+    snap_b = _request("POST", f"{TRACEMALLOC_BASE}/snapshot", {"top": 10})
+    print(json.dumps(snap_b, indent=2))
+
+    section("6. compare A → B (top growers)")
+    diff = _request("POST", f"{TRACEMALLOC_BASE}/compare", {"top": 10})
+    print(json.dumps(diff, indent=2))
+
+    section("7. list all snapshots on disk")
+    listing = _request("GET", f"{TRACEMALLOC_BASE}/snapshots")
+    print(json.dumps(listing, indent=2))
+    for item in listing.get("snapshots", []):
+        path = item.get("file_path")
+        if path and os.path.isfile(path):
+            size = os.path.getsize(path)
+            print(f"  - {path}  ({size:,} bytes)")
+
+    section("8. stop tracemalloc")
+    print(json.dumps(_request("POST", f"{TRACEMALLOC_BASE}/stop"), indent=2))
+
+    print()
+    print("✅ tracemalloc lifecycle finished.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/example/fastapi_per_route_history_example.py
+++ b/example/fastapi_per_route_history_example.py
@@ -8,8 +8,8 @@ contains the route path, HTTP method, duration in milliseconds, HTTP status
 code, and an optional profile output string captured at request time.
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 

--- a/example/fastapi_runtime_toggle_example.py
+++ b/example/fastapi_runtime_toggle_example.py
@@ -25,8 +25,8 @@ Try the following after starting the server:
        -d '{"slow_request_threshold_ms": 200}'
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 

--- a/example/fastapi_sampling_rate_example.py
+++ b/example/fastapi_sampling_rate_example.py
@@ -6,8 +6,8 @@ Setting sample_rate=0.1 means only ~10% of requests will be profiled,
 which reduces overhead in high-traffic production environments.
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 

--- a/example/fastapi_stats_dashboard_example.py
+++ b/example/fastapi_stats_dashboard_example.py
@@ -12,8 +12,8 @@ The dashboard shows per-route statistics including request count,
 error count, average / p95 / p99 / max duration in milliseconds.
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
@@ -23,10 +23,10 @@ app = FastAPI()
 app.add_middleware(
     PyInstrumentProfilerMiddleware,
     server_app=app,
-    enable_dashboard=True,          # Mount the built-in Web UI Dashboard
-    dashboard_path="/__profiler__", # URL prefix for the dashboard (default)
+    enable_dashboard=True,           # Mount the built-in Web UI Dashboard
+    dashboard_path="/__profiler__",  # URL prefix for the dashboard (default)
     is_print_each_request=True,
-    filter_paths=["/__profiler__"], # Exclude dashboard requests from stats
+    filter_paths=["/__profiler__"],  # Exclude dashboard requests from stats
 )
 
 

--- a/example/fastapi_to_html_example.py
+++ b/example/fastapi_to_html_example.py
@@ -3,13 +3,12 @@ This example shows how to output the profile
 to a html file.
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from fastapi_profiler import PyInstrumentProfilerMiddleware
-
 
 app = FastAPI()
 app.add_middleware(

--- a/example/fastapi_to_json_example.py
+++ b/example/fastapi_to_json_example.py
@@ -3,8 +3,8 @@ This example shows how to output the profile
 to json file.
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 

--- a/example/fastapi_to_prof_example.py
+++ b/example/fastapi_to_prof_example.py
@@ -3,13 +3,12 @@ This example shows how to output the profile
 to a .prof file.
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from fastapi_profiler import PyInstrumentProfilerMiddleware
-
 
 app = FastAPI()
 app.add_middleware(

--- a/example/fastapi_to_speedscope_example.py
+++ b/example/fastapi_to_speedscope_example.py
@@ -3,8 +3,8 @@ This example shows how to output the profile
 to json file.
 """
 import os
-import uvicorn
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 

--- a/fastapi_profiler/__init__.py
+++ b/fastapi_profiler/__init__.py
@@ -1,4 +1,6 @@
 from ._version import __author__, __version__
+from .memory import MEMRAY_AVAILABLE, MemrayProfiler, TracemallocProfiler
+from .memory_middleware import MemoryProfilerMiddleware
 from .profiler import PyInstrumentProfilerMiddleware
 from .stats import ProfileRecord, RouteStats, StatsCollector
 
@@ -6,6 +8,10 @@ __all__ = [
     "__version__",
     "__author__",
     "PyInstrumentProfilerMiddleware",
+    "MemoryProfilerMiddleware",
+    "TracemallocProfiler",
+    "MemrayProfiler",
+    "MEMRAY_AVAILABLE",
     "StatsCollector",
     "ProfileRecord",
     "RouteStats",

--- a/fastapi_profiler/_version.py
+++ b/fastapi_profiler/_version.py
@@ -1,2 +1,2 @@
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 __author__ = "sunhailin-Leo"

--- a/fastapi_profiler/memory/__init__.py
+++ b/fastapi_profiler/memory/__init__.py
@@ -1,0 +1,26 @@
+"""Memory profiling sub-package for fastapi_profiler.
+
+This package provides two complementary memory profilers:
+
+- :mod:`tracemalloc_profiler`: standard-library based, zero extra deps,
+  supports ``start``/``stop``/``snapshot``/``compare`` operations.
+- :mod:`memray_profiler`: optional third-party (Bloomberg ``memray``)
+  full native + Python allocation tracker with ``.bin`` output that can
+  be rendered with ``memray flamegraph`` / ``memray tree`` CLIs.
+
+Both profilers are exposed via :class:`MemoryProfilerMiddleware`
+(see :mod:`fastapi_profiler.memory_middleware`) which mounts an HTTP
+control router on the host application.
+"""
+
+from fastapi_profiler.memory.memray_profiler import (
+    MEMRAY_AVAILABLE,
+    MemrayProfiler,
+)
+from fastapi_profiler.memory.tracemalloc_profiler import TracemallocProfiler
+
+__all__ = [
+    "TracemallocProfiler",
+    "MemrayProfiler",
+    "MEMRAY_AVAILABLE",
+]

--- a/fastapi_profiler/memory/memray_profiler.py
+++ b/fastapi_profiler/memory/memray_profiler.py
@@ -1,0 +1,255 @@
+"""memray-based memory profiler (optional dependency).
+
+`memray <https://github.com/bloomberg/memray>`_ is a native allocation
+tracker that produces ``.bin`` capture files which can be rendered by the
+``memray`` CLI (``memray flamegraph``, ``memray tree``, ``memray stats``).
+
+Constraints
+-----------
+- ``memray`` is **not available on Windows** (Linux + macOS only).
+- A single Python process can have **at most one** active
+  :class:`memray.Tracker` at a time.  This wrapper enforces that with a
+  process-wide lock and an internal state machine.
+- Tracking is **process-global**: every allocation in the process is
+  recorded for the lifetime of the session, regardless of which thread or
+  request triggered it.
+
+Lifecycle
+---------
+1. ``start(...)`` — instantiate ``memray.Tracker`` and enter its context.
+2. ``stop()`` — exit the tracker context which finalises the ``.bin`` file.
+3. ``status()`` — query current state.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+import threading
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - import guard exercised indirectly via tests
+    import memray  # type: ignore[import-not-found]
+
+    MEMRAY_AVAILABLE = True
+    _MEMRAY_IMPORT_ERROR: str | None = None
+except Exception as exc:  # noqa: BLE001 - capture any import-time failure
+    memray = None  # type: ignore[assignment]
+    MEMRAY_AVAILABLE = False
+    _MEMRAY_IMPORT_ERROR = f"{type(exc).__name__}: {exc}"
+
+IS_WINDOWS = sys.platform.startswith("win") or platform.system() == "Windows"
+
+
+class MemrayUnavailableError(RuntimeError):
+    """Raised when memray is requested but cannot be used on this platform."""
+
+
+class MemrayProfiler:
+    """Process-wide controller for ``memray.Tracker``.
+
+    Parameters
+    ----------
+    output_dir:
+        Directory where ``.bin`` capture files are written.  Created on demand.
+    """
+
+    DEFAULT_OUTPUT_EXT = ".bin"
+
+    def __init__(self, output_dir: str = "./mem-snapshots") -> None:
+        self._output_dir = output_dir
+        self._lock = threading.Lock()
+        self._tracker: Any | None = None  # memray.Tracker
+        self._tracker_cm: Any | None = None  # context manager handle
+        self._current_output: str | None = None
+        self._started_at: float | None = None
+        self._session_id: str | None = None
+
+    # ------------------------------------------------------------------
+    # Capability / introspection
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def is_available() -> Dict[str, Any]:
+        """Return availability info: ``{available, platform_supported, reason}``."""
+        if IS_WINDOWS:
+            return {
+                "available": False,
+                "platform_supported": False,
+                "reason": "memray does not support Windows",
+            }
+        if not MEMRAY_AVAILABLE:
+            return {
+                "available": False,
+                "platform_supported": True,
+                "reason": (
+                    "memray is not installed. Install with: "
+                    "pip install 'fastapi_profiler[memray]'"
+                ),
+                "import_error": _MEMRAY_IMPORT_ERROR,
+            }
+        return {"available": True, "platform_supported": True, "reason": None}
+
+    def is_running(self) -> bool:
+        with self._lock:
+            return self._tracker is not None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(
+        self,
+        output_path: str | None = None,
+        native: bool = False,
+        follow_fork: bool = False,
+        trace_python_allocators: bool = False,
+    ) -> Dict[str, Any]:
+        """Start a new memray tracking session.
+
+        Parameters
+        ----------
+        output_path:
+            Explicit ``.bin`` output path.  When omitted a unique file is
+            created under ``output_dir``.
+        native:
+            Capture C/C++ stack frames in addition to Python frames.
+        follow_fork:
+            Continue tracking child processes spawned via ``fork()``.
+        trace_python_allocators:
+            Also track allocations made via Python's allocator domain.
+        """
+        self._require_available()
+
+        with self._lock:
+            if self._tracker is not None:
+                raise RuntimeError(
+                    "memray tracker already running; call stop() first"
+                )
+
+            os.makedirs(self._output_dir, exist_ok=True)
+            session_id = self._make_session_id()
+            resolved_output = output_path or os.path.join(
+                self._output_dir, f"memray-{session_id}{self.DEFAULT_OUTPUT_EXT}"
+            )
+
+            # memray.Tracker is a context manager; we drive it manually so
+            # that start/stop can be independent HTTP calls.
+            tracker = memray.Tracker(  # type: ignore[union-attr]
+                resolved_output,
+                native_traces=native,
+                follow_fork=follow_fork,
+                trace_python_allocators=trace_python_allocators,
+            )
+            try:
+                tracker.__enter__()
+            except Exception:
+                # Surface the failure but keep state clean.
+                self._tracker = None
+                self._tracker_cm = None
+                self._current_output = None
+                self._started_at = None
+                self._session_id = None
+                raise
+
+            self._tracker = tracker
+            self._tracker_cm = tracker
+            self._current_output = resolved_output
+            self._started_at = time.time()
+            self._session_id = session_id
+
+            return {
+                "running": True,
+                "session_id": session_id,
+                "output_path": resolved_output,
+                "native": native,
+                "follow_fork": follow_fork,
+                "trace_python_allocators": trace_python_allocators,
+                "started_at": self._started_at,
+                "message": "started",
+            }
+
+    def stop(self) -> Dict[str, Any]:
+        """Stop the active tracking session and finalise the ``.bin`` file."""
+        with self._lock:
+            if self._tracker is None or self._tracker_cm is None:
+                return {
+                    "running": False,
+                    "message": "not running",
+                }
+
+            output = self._current_output
+            session_id = self._session_id
+            started_at = self._started_at
+
+            try:
+                self._tracker_cm.__exit__(None, None, None)
+            finally:
+                self._tracker = None
+                self._tracker_cm = None
+                self._current_output = None
+                self._started_at = None
+                self._session_id = None
+
+            duration = time.time() - started_at if started_at else 0.0
+            file_size = (
+                os.path.getsize(output)
+                if output and os.path.isfile(output)
+                else 0
+            )
+            return {
+                "running": False,
+                "session_id": session_id,
+                "output_path": output,
+                "duration_seconds": duration,
+                "file_size_bytes": file_size,
+                "message": "stopped",
+                "hint": (
+                    "Render with: "
+                    f"memray flamegraph {output}"
+                    if output
+                    else None
+                ),
+            }
+
+    def status(self) -> Dict[str, Any]:
+        """Return current session state."""
+        with self._lock:
+            availability = self.is_available()
+            running = self._tracker is not None
+            out: Dict[str, Any] = {
+                "available": availability["available"],
+                "platform_supported": availability["platform_supported"],
+                "running": running,
+                "output_dir": self._output_dir,
+            }
+            if availability["reason"]:
+                out["reason"] = availability["reason"]
+            if running:
+                out.update({
+                    "session_id": self._session_id,
+                    "output_path": self._current_output,
+                    "started_at": self._started_at,
+                    "running_seconds": (
+                        time.time() - self._started_at
+                        if self._started_at
+                        else 0.0
+                    ),
+                })
+            return out
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_session_id() -> str:
+        return f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+    def _require_available(self) -> None:
+        info = self.is_available()
+        if not info["available"]:
+            raise MemrayUnavailableError(info["reason"] or "memray unavailable")

--- a/fastapi_profiler/memory/tracemalloc_profiler.py
+++ b/fastapi_profiler/memory/tracemalloc_profiler.py
@@ -1,0 +1,267 @@
+"""tracemalloc-based memory profiler.
+
+A thin, thread-safe wrapper around the standard-library :mod:`tracemalloc`
+module.  Designed to be driven by HTTP control endpoints exposed by
+:class:`fastapi_profiler.memory_middleware.MemoryProfilerMiddleware`.
+
+Lifecycle
+---------
+1. ``start(frames=...)`` — calls :func:`tracemalloc.start` and remembers the
+   configured frame depth.  Idempotent: re-calling ``start`` is a no-op.
+2. ``snapshot()`` — captures a :class:`tracemalloc.Snapshot`, persists it to
+   ``snapshot_dir`` via :py:meth:`tracemalloc.Snapshot.dump` and returns a
+   metadata dict (path, top-N statistics, traced memory).
+3. ``compare(latest=True)`` — diffs the two most recent snapshots and
+   returns the top growers.
+4. ``stop()`` — calls :func:`tracemalloc.stop` and clears in-memory snapshot
+   state (files on disk are kept).
+
+Snapshot files use the ``.snap`` extension and are written via the official
+:py:meth:`tracemalloc.Snapshot.dump` API which is stable across CPython
+versions.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import tracemalloc
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class TracemallocProfiler:
+    """Thread-safe controller for ``tracemalloc``.
+
+    Parameters
+    ----------
+    snapshot_dir:
+        Directory where ``.snap`` files are written.  Created on demand.
+    default_frames:
+        Frame depth to use when ``start()`` is called without an explicit
+        ``frames`` argument.  Higher values give richer tracebacks but
+        increase overhead and memory usage.
+    default_top:
+        Default number of top allocation entries to return from
+        ``snapshot()`` / ``compare()``.
+    """
+
+    DEFAULT_FRAMES = 25
+    DEFAULT_TOP = 20
+    SNAPSHOT_EXT = ".snap"
+
+    def __init__(
+        self,
+        snapshot_dir: str = "./mem-snapshots",
+        default_frames: int = DEFAULT_FRAMES,
+        default_top: int = DEFAULT_TOP,
+    ) -> None:
+        self._snapshot_dir = snapshot_dir
+        self._default_frames = default_frames
+        self._default_top = default_top
+
+        self._lock = threading.Lock()
+        # Ordered list of (snapshot_id, file_path, snapshot) tuples.
+        # Keeping the in-memory Snapshot avoids a re-load round-trip for
+        # the common "compare last two" use case.
+        self._snapshots: List[Tuple[str, str, tracemalloc.Snapshot]] = []
+        self._frames: int = default_frames
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def is_running(self) -> bool:
+        """Return True when ``tracemalloc`` is currently tracing."""
+        return tracemalloc.is_tracing()
+
+    def start(self, frames: int | None = None) -> Dict[str, Any]:
+        """Start ``tracemalloc`` if not already running.
+
+        Returns a status dict.  Calling ``start`` while already running is a
+        no-op and the existing frame depth is preserved.
+        """
+        with self._lock:
+            if tracemalloc.is_tracing():
+                return self._status_locked(message="already running")
+
+            self._frames = int(frames if frames is not None else self._default_frames)
+            if self._frames < 1:
+                raise ValueError("frames must be >= 1")
+            tracemalloc.start(self._frames)
+            return self._status_locked(message="started")
+
+    def stop(self) -> Dict[str, Any]:
+        """Stop ``tracemalloc`` and clear in-memory snapshot state."""
+        with self._lock:
+            was_running = tracemalloc.is_tracing()
+            if was_running:
+                tracemalloc.stop()
+            self._snapshots.clear()
+            return {
+                "running": False,
+                "message": "stopped" if was_running else "not running",
+                "frames": self._frames,
+                "snapshot_count": 0,
+            }
+
+    def status(self) -> Dict[str, Any]:
+        """Return current status (running flag, traced memory, snapshot count)."""
+        with self._lock:
+            return self._status_locked()
+
+    # ------------------------------------------------------------------
+    # Snapshot operations
+    # ------------------------------------------------------------------
+
+    def snapshot(self, top: int | None = None) -> Dict[str, Any]:
+        """Capture a snapshot, persist to disk, return metadata + top stats."""
+        if not tracemalloc.is_tracing():
+            raise RuntimeError(
+                "tracemalloc is not running; call start() before snapshot()"
+            )
+
+        top_n = int(top if top is not None else self._default_top)
+        if top_n < 1:
+            raise ValueError("top must be >= 1")
+
+        snap = tracemalloc.take_snapshot()
+        # Filter out tracemalloc's own frames so users only see their code.
+        snap = snap.filter_traces((
+            tracemalloc.Filter(False, tracemalloc.__file__),
+            tracemalloc.Filter(False, __file__),
+        ))
+
+        os.makedirs(self._snapshot_dir, exist_ok=True)
+        snapshot_id = self._make_snapshot_id()
+        file_path = os.path.join(self._snapshot_dir, snapshot_id + self.SNAPSHOT_EXT)
+        snap.dump(file_path)
+
+        current, peak = tracemalloc.get_traced_memory()
+
+        with self._lock:
+            self._snapshots.append((snapshot_id, file_path, snap))
+
+        return {
+            "snapshot_id": snapshot_id,
+            "file_path": file_path,
+            "traced_memory_current_bytes": current,
+            "traced_memory_peak_bytes": peak,
+            "top": _format_statistics(snap.statistics("lineno"), top_n),
+        }
+
+    def compare(
+        self,
+        top: int | None = None,
+        snapshot_a: str | None = None,
+        snapshot_b: str | None = None,
+    ) -> Dict[str, Any]:
+        """Diff two snapshots and return the top growers.
+
+        By default compares the two most recent snapshots.  If
+        ``snapshot_a`` / ``snapshot_b`` are provided they must reference
+        snapshot ids previously returned by :py:meth:`snapshot`.
+        """
+        top_n = int(top if top is not None else self._default_top)
+        if top_n < 1:
+            raise ValueError("top must be >= 1")
+
+        with self._lock:
+            snap_a, snap_b, id_a, id_b = self._resolve_pair_locked(
+                snapshot_a, snapshot_b
+            )
+
+        diffs = snap_b.compare_to(snap_a, "lineno")
+        return {
+            "snapshot_a": id_a,
+            "snapshot_b": id_b,
+            "top": _format_statistics(diffs, top_n, is_diff=True),
+        }
+
+    def list_snapshots(self) -> List[Dict[str, Any]]:
+        """Return metadata for all snapshots captured in the current session."""
+        with self._lock:
+            return [
+                {"snapshot_id": sid, "file_path": fpath}
+                for sid, fpath, _ in self._snapshots
+            ]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _status_locked(self, message: str | None = None) -> Dict[str, Any]:
+        running = tracemalloc.is_tracing()
+        current = peak = 0
+        if running:
+            current, peak = tracemalloc.get_traced_memory()
+        out: Dict[str, Any] = {
+            "running": running,
+            "frames": self._frames,
+            "snapshot_count": len(self._snapshots),
+            "snapshot_dir": self._snapshot_dir,
+            "traced_memory_current_bytes": current,
+            "traced_memory_peak_bytes": peak,
+        }
+        if message is not None:
+            out["message"] = message
+        return out
+
+    def _resolve_pair_locked(
+        self,
+        snapshot_a: str | None,
+        snapshot_b: str | None,
+    ) -> Tuple[tracemalloc.Snapshot, tracemalloc.Snapshot, str, str]:
+        if snapshot_a is None and snapshot_b is None:
+            if len(self._snapshots) < 2:
+                raise RuntimeError(
+                    "need at least two snapshots to compare; "
+                    "call snapshot() at least twice first"
+                )
+            id_a, _, snap_a = self._snapshots[-2]
+            id_b, _, snap_b = self._snapshots[-1]
+            return snap_a, snap_b, id_a, id_b
+
+        if snapshot_a is None or snapshot_b is None:
+            raise ValueError(
+                "snapshot_a and snapshot_b must both be provided or both omitted"
+            )
+
+        index_by_id = {sid: (sid, snap) for sid, _, snap in self._snapshots}
+        if snapshot_a not in index_by_id or snapshot_b not in index_by_id:
+            raise KeyError("unknown snapshot_id")
+        id_a, snap_a = index_by_id[snapshot_a]
+        id_b, snap_b = index_by_id[snapshot_b]
+        return snap_a, snap_b, id_a, id_b
+
+    @staticmethod
+    def _make_snapshot_id() -> str:
+        # Sortable + unique: <unix_seconds>-<short uuid>
+        return f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+
+def _format_statistics(
+    stats: List[Any],
+    top_n: int,
+    is_diff: bool = False,
+) -> List[Dict[str, Any]]:
+    """Convert tracemalloc.Statistic / StatisticDiff list into JSON-friendly dicts."""
+    out: List[Dict[str, Any]] = []
+    for stat in stats[:top_n]:
+        frame = stat.traceback[0] if stat.traceback else None
+        item: Dict[str, Any] = {
+            "size_bytes": int(stat.size),
+            "count": int(stat.count),
+            "file": frame.filename if frame else "<unknown>",
+            "line": int(frame.lineno) if frame else 0,
+            "traceback": [
+                f"{f.filename}:{f.lineno}" for f in stat.traceback
+            ],
+        }
+        if is_diff:
+            # StatisticDiff exposes size_diff / count_diff in addition.
+            item["size_diff_bytes"] = int(getattr(stat, "size_diff", 0))
+            item["count_diff"] = int(getattr(stat, "count_diff", 0))
+        out.append(item)
+    return out

--- a/fastapi_profiler/memory_dashboard.py
+++ b/fastapi_profiler/memory_dashboard.py
@@ -1,0 +1,279 @@
+"""HTTP control router for the memory profiler.
+
+Exposes JSON endpoints to drive :class:`TracemallocProfiler` and
+:class:`MemrayProfiler`.  Mounted by
+:class:`fastapi_profiler.memory_middleware.MemoryProfilerMiddleware` at a
+configurable path (default ``/__memory_profiler__``).
+
+Routes
+------
+GET  /                              Minimal HTML page with usage hints.
+GET  /status                        Aggregated status of both profilers.
+
+GET  /tracemalloc/status            tracemalloc status.
+POST /tracemalloc/start             {"frames": int?}
+POST /tracemalloc/stop
+POST /tracemalloc/snapshot          {"top": int?}
+POST /tracemalloc/compare           {"top": int?, "snapshot_a": str?, "snapshot_b": str?}
+GET  /tracemalloc/snapshots         List captured snapshots.
+
+GET  /memray/status                 memray availability + current session.
+POST /memray/start                  {"output_path": str?, "native": bool?, "follow_fork": bool?, "trace_python_allocators": bool?}
+POST /memray/stop
+
+No authentication is enforced; protect the mount path via reverse proxy
+ACLs or by setting ``filter_paths`` on any other middleware.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse
+from starlette.routing import Route, Router
+
+from fastapi_profiler.memory.memray_profiler import (
+    MemrayProfiler,
+    MemrayUnavailableError,
+)
+from fastapi_profiler.memory.tracemalloc_profiler import TracemallocProfiler
+
+_INDEX_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>FastAPI Memory Profiler</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f0f2f5;color:#333;padding:24px;max-width:920px;margin:0 auto}
+h1{color:#1a1a2e;margin-bottom:8px;font-size:22px}
+h2{color:#2c3e50;margin-top:24px;margin-bottom:8px;font-size:16px}
+p{color:#555;margin-bottom:12px}
+code{background:#eef1f5;padding:2px 6px;border-radius:4px;font-family:'SF Mono',Menlo,monospace;font-size:13px}
+pre{background:#1e1e2e;color:#dcdcdc;padding:12px 14px;border-radius:6px;overflow-x:auto;font-size:12px;line-height:1.5}
+ul{margin-left:18px;color:#555;line-height:1.7}
+.tag{display:inline-block;background:#3498db;color:#fff;padding:1px 8px;border-radius:3px;font-size:11px;font-weight:600;margin-right:6px}
+.tag-post{background:#27ae60}
+.tag-get{background:#3498db}
+</style>
+</head>
+<body>
+<h1>🧠 FastAPI Memory Profiler</h1>
+<p>HTTP control plane for <code>tracemalloc</code> and <code>memray</code>. All endpoints accept/return JSON.</p>
+
+<h2>Status</h2>
+<ul>
+  <li><span class="tag tag-get">GET</span><code>./status</code> — combined status</li>
+</ul>
+
+<h2>tracemalloc</h2>
+<ul>
+  <li><span class="tag tag-get">GET</span><code>./tracemalloc/status</code></li>
+  <li><span class="tag tag-post">POST</span><code>./tracemalloc/start</code> — body: <code>{"frames": 25}</code></li>
+  <li><span class="tag tag-post">POST</span><code>./tracemalloc/stop</code></li>
+  <li><span class="tag tag-post">POST</span><code>./tracemalloc/snapshot</code> — body: <code>{"top": 20}</code></li>
+  <li><span class="tag tag-post">POST</span><code>./tracemalloc/compare</code> — body: <code>{"top": 20}</code></li>
+  <li><span class="tag tag-get">GET</span><code>./tracemalloc/snapshots</code></li>
+</ul>
+
+<h2>memray (optional)</h2>
+<ul>
+  <li><span class="tag tag-get">GET</span><code>./memray/status</code></li>
+  <li><span class="tag tag-post">POST</span><code>./memray/start</code> — body: <code>{"native": true, "follow_fork": false}</code></li>
+  <li><span class="tag tag-post">POST</span><code>./memray/stop</code></li>
+</ul>
+<p>After stopping a memray session, render the resulting <code>.bin</code> file with:</p>
+<pre>memray flamegraph &lt;output_path&gt;
+memray tree       &lt;output_path&gt;
+memray stats      &lt;output_path&gt;</pre>
+</body>
+</html>"""
+
+
+def _bad_request(message: str) -> JSONResponse:
+    return JSONResponse({"error": message}, status_code=400)
+
+
+def _service_unavailable(message: str, **extra: Any) -> JSONResponse:
+    body: Dict[str, Any] = {"error": message}
+    body.update(extra)
+    return JSONResponse(body, status_code=503)
+
+
+async def _read_json_body(request: Request) -> Dict[str, Any] | None:
+    """Return parsed JSON dict, or None when body is empty.  Raises ValueError on bad JSON."""
+    raw = await request.body()
+    if not raw:
+        return None
+    try:
+        import json
+        data = json.loads(raw)
+    except Exception as exc:
+        raise ValueError(f"invalid JSON body: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("JSON body must be an object")
+    return data
+
+
+def create_memory_router(
+    tracemalloc_profiler: TracemallocProfiler,
+    memray_profiler: MemrayProfiler,
+) -> Router:
+    """Return a Starlette ``Router`` exposing memory profiler controls."""
+
+    # ------------------------------------------------------------------
+    # Index + combined status
+    # ------------------------------------------------------------------
+
+    async def get_index(_: Request) -> HTMLResponse:
+        return HTMLResponse(content=_INDEX_HTML)
+
+    async def get_combined_status(_: Request) -> JSONResponse:
+        return JSONResponse({
+            "tracemalloc": tracemalloc_profiler.status(),
+            "memray": memray_profiler.status(),
+        })
+
+    # ------------------------------------------------------------------
+    # tracemalloc routes
+    # ------------------------------------------------------------------
+
+    async def tm_status(_: Request) -> JSONResponse:
+        return JSONResponse(tracemalloc_profiler.status())
+
+    async def tm_start(request: Request) -> JSONResponse:
+        try:
+            body = await _read_json_body(request) or {}
+        except ValueError as exc:
+            return _bad_request(str(exc))
+
+        frames = body.get("frames")
+        if frames is not None:
+            try:
+                frames = int(frames)
+            except (TypeError, ValueError):
+                return _bad_request("frames must be a positive integer")
+            if frames < 1:
+                return _bad_request("frames must be a positive integer")
+
+        try:
+            return JSONResponse(tracemalloc_profiler.start(frames=frames))
+        except ValueError as exc:
+            return _bad_request(str(exc))
+
+    async def tm_stop(_: Request) -> JSONResponse:
+        return JSONResponse(tracemalloc_profiler.stop())
+
+    async def tm_snapshot(request: Request) -> JSONResponse:
+        try:
+            body = await _read_json_body(request) or {}
+        except ValueError as exc:
+            return _bad_request(str(exc))
+
+        top = body.get("top")
+        if top is not None:
+            try:
+                top = int(top)
+            except (TypeError, ValueError):
+                return _bad_request("top must be a positive integer")
+            if top < 1:
+                return _bad_request("top must be a positive integer")
+
+        try:
+            return JSONResponse(tracemalloc_profiler.snapshot(top=top))
+        except RuntimeError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        except ValueError as exc:
+            return _bad_request(str(exc))
+
+    async def tm_compare(request: Request) -> JSONResponse:
+        try:
+            body = await _read_json_body(request) or {}
+        except ValueError as exc:
+            return _bad_request(str(exc))
+
+        top = body.get("top")
+        if top is not None:
+            try:
+                top = int(top)
+            except (TypeError, ValueError):
+                return _bad_request("top must be a positive integer")
+            if top < 1:
+                return _bad_request("top must be a positive integer")
+
+        snapshot_a = body.get("snapshot_a")
+        snapshot_b = body.get("snapshot_b")
+        if snapshot_a is not None and not isinstance(snapshot_a, str):
+            return _bad_request("snapshot_a must be a string")
+        if snapshot_b is not None and not isinstance(snapshot_b, str):
+            return _bad_request("snapshot_b must be a string")
+
+        try:
+            return JSONResponse(tracemalloc_profiler.compare(
+                top=top,
+                snapshot_a=snapshot_a,
+                snapshot_b=snapshot_b,
+            ))
+        except KeyError as exc:
+            return JSONResponse({"error": str(exc).strip("'")}, status_code=404)
+        except RuntimeError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        except ValueError as exc:
+            return _bad_request(str(exc))
+
+    async def tm_list_snapshots(_: Request) -> JSONResponse:
+        return JSONResponse({"snapshots": tracemalloc_profiler.list_snapshots()})
+
+    # ------------------------------------------------------------------
+    # memray routes
+    # ------------------------------------------------------------------
+
+    async def mr_status(_: Request) -> JSONResponse:
+        return JSONResponse(memray_profiler.status())
+
+    async def mr_start(request: Request) -> JSONResponse:
+        try:
+            body = await _read_json_body(request) or {}
+        except ValueError as exc:
+            return _bad_request(str(exc))
+
+        output_path = body.get("output_path")
+        if output_path is not None and not isinstance(output_path, str):
+            return _bad_request("output_path must be a string")
+
+        bool_fields = ("native", "follow_fork", "trace_python_allocators")
+        kwargs: Dict[str, Any] = {}
+        for field_name in bool_fields:
+            if field_name in body:
+                value = body[field_name]
+                if not isinstance(value, bool):
+                    return _bad_request(f"{field_name} must be a boolean")
+                kwargs[field_name] = value
+
+        try:
+            result = memray_profiler.start(output_path=output_path, **kwargs)
+            return JSONResponse(result)
+        except MemrayUnavailableError as exc:
+            return _service_unavailable(
+                str(exc),
+                availability=memray_profiler.is_available(),
+            )
+        except RuntimeError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+
+    async def mr_stop(_: Request) -> JSONResponse:
+        return JSONResponse(memray_profiler.stop())
+
+    return Router(routes=[
+        Route("/", endpoint=get_index, methods=["GET"]),
+        Route("/status", endpoint=get_combined_status, methods=["GET"]),
+        Route("/tracemalloc/status", endpoint=tm_status, methods=["GET"]),
+        Route("/tracemalloc/start", endpoint=tm_start, methods=["POST"]),
+        Route("/tracemalloc/stop", endpoint=tm_stop, methods=["POST"]),
+        Route("/tracemalloc/snapshot", endpoint=tm_snapshot, methods=["POST"]),
+        Route("/tracemalloc/compare", endpoint=tm_compare, methods=["POST"]),
+        Route("/tracemalloc/snapshots", endpoint=tm_list_snapshots, methods=["GET"]),
+        Route("/memray/status", endpoint=mr_status, methods=["GET"]),
+        Route("/memray/start", endpoint=mr_start, methods=["POST"]),
+        Route("/memray/stop", endpoint=mr_stop, methods=["POST"]),
+    ])

--- a/fastapi_profiler/memory_middleware.py
+++ b/fastapi_profiler/memory_middleware.py
@@ -1,0 +1,174 @@
+"""ASGI middleware exposing memory profiling control endpoints.
+
+This middleware is intentionally separate from
+:class:`fastapi_profiler.profiler.PyInstrumentProfilerMiddleware`:
+
+- CPU/wall-time profiling is per-request, sampling-based.
+- Memory profiling is process-global and operator-driven (start/stop/dump
+  via HTTP).
+
+Pass-through behaviour
+----------------------
+The middleware does **not** profile or record per-request data.  Its only
+runtime job is to short-circuit requests targeted at its own dashboard
+path so that they cannot recurse into other middlewares' profiling logic
+(e.g. they never appear in pyinstrument profiles).  All other requests
+are forwarded unchanged.
+
+Usage
+-----
+.. code-block:: python
+
+    from fastapi import FastAPI
+    from fastapi_profiler import MemoryProfilerMiddleware
+
+    app = FastAPI()
+    app.add_middleware(
+        MemoryProfilerMiddleware,
+        server_app=app,
+        snapshot_dir="./mem-snapshots",
+        autostart_tracemalloc=False,
+    )
+
+    # Then drive it via HTTP:
+    #   curl -XPOST http://localhost:8080/__memory_profiler__/tracemalloc/start
+    #   curl -XPOST http://localhost:8080/__memory_profiler__/tracemalloc/snapshot
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Callable, Optional
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from fastapi_profiler.memory.memray_profiler import MemrayProfiler
+from fastapi_profiler.memory.tracemalloc_profiler import TracemallocProfiler
+from fastapi_profiler.memory_dashboard import create_memory_router
+
+
+class MemoryProfilerMiddleware:
+    """ASGI middleware that mounts a memory profiler control router.
+
+    Parameters
+    ----------
+    app:
+        The ASGI application to wrap.
+    server_app:
+        The host Starlette/FastAPI application.  Required to mount the
+        control router and to register a shutdown hook that finalises any
+        running memray session.
+    memory_dashboard_path:
+        URL prefix where the memory profiler endpoints are mounted
+        (default ``"/__memory_profiler__"``).
+    snapshot_dir:
+        Directory used for both tracemalloc ``.snap`` files and memray
+        ``.bin`` files (default ``"./mem-snapshots"``).
+    tracemalloc_frames:
+        Default frame depth passed to ``tracemalloc.start`` when the
+        ``/tracemalloc/start`` endpoint is called without an explicit
+        ``frames`` value.
+    tracemalloc_top:
+        Default top-N size for ``snapshot`` / ``compare`` responses.
+    autostart_tracemalloc:
+        When True, ``tracemalloc.start`` is invoked during middleware
+        construction.  Useful when you want to capture allocations from
+        application startup as well.  Defaults to False so the middleware
+        has zero overhead until explicitly activated.
+    """
+
+    DEFAULT_PATH = "/__memory_profiler__"
+    DEFAULT_SNAPSHOT_DIR = "./mem-snapshots"
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        server_app=None,
+        memory_dashboard_path: str = DEFAULT_PATH,
+        snapshot_dir: str = DEFAULT_SNAPSHOT_DIR,
+        tracemalloc_frames: int = TracemallocProfiler.DEFAULT_FRAMES,
+        tracemalloc_top: int = TracemallocProfiler.DEFAULT_TOP,
+        autostart_tracemalloc: bool = False,
+    ) -> None:
+        self.app = app
+        self._dashboard_path = memory_dashboard_path.rstrip("/") or self.DEFAULT_PATH
+        self._snapshot_dir = snapshot_dir
+
+        self._tracemalloc = TracemallocProfiler(
+            snapshot_dir=snapshot_dir,
+            default_frames=tracemalloc_frames,
+            default_top=tracemalloc_top,
+        )
+        self._memray = MemrayProfiler(output_dir=snapshot_dir)
+
+        if server_app is None:
+            warnings.warn(
+                "MemoryProfilerMiddleware requires server_app to mount the "
+                "control router.  The HTTP endpoints will not be available; "
+                "pass server_app=app to enable them.",
+                UserWarning,
+                stacklevel=2,
+            )
+        else:
+            router = create_memory_router(
+                tracemalloc_profiler=self._tracemalloc,
+                memray_profiler=self._memray,
+            )
+            server_app.mount(self._dashboard_path, app=router)
+            # Best-effort cleanup of an active memray session on shutdown
+            # so that the .bin file is finalised even if the operator
+            # forgets to call /memray/stop.
+            server_app.router.on_event("shutdown")(self._on_shutdown)
+
+        if autostart_tracemalloc:
+            self._tracemalloc.start(frames=tracemalloc_frames)
+
+    # ------------------------------------------------------------------
+    # ASGI entry point
+    # ------------------------------------------------------------------
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # We want this middleware to be transparent for everything that's
+        # not the memory dashboard itself.  The dashboard router is mounted
+        # directly on the host app, so we simply forward all requests.
+        await self.app(scope, receive, send)
+
+    # ------------------------------------------------------------------
+    # Accessors (used by tests and advanced integrations)
+    # ------------------------------------------------------------------
+
+    @property
+    def tracemalloc_profiler(self) -> TracemallocProfiler:
+        return self._tracemalloc
+
+    @property
+    def memray_profiler(self) -> MemrayProfiler:
+        return self._memray
+
+    @property
+    def dashboard_path(self) -> str:
+        return self._dashboard_path
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+
+    async def _on_shutdown(self) -> None:
+        # Finalise any running memray session so the capture file is valid.
+        try:
+            if self._memray.is_running():
+                self._memray.stop()
+        except Exception:  # noqa: BLE001 - shutdown must never raise
+            pass
+        # tracemalloc cleanup is cheap and idempotent.
+        try:
+            if self._tracemalloc.is_running():
+                self._tracemalloc.stop()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Compatibility shim so users can register the hook manually if they
+    # constructed the middleware without ``server_app``.
+    def get_shutdown_handler(self) -> Callable[[], Any] | None:
+        return self._on_shutdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_profiler"
-version = "1.5.0"
+version = "1.6.0"
 description = "A FastAPI Middleware of pyinstrument to check your service performance."
 readme = "README.md"
 license = { text = "MIT" }
@@ -30,6 +30,9 @@ dependencies = [
     "pyinstrument>=4.4.0",
 ]
 
+[project.optional-dependencies]
+memray = ["memray>=1.10.0; sys_platform != 'win32'"]
+
 [project.urls]
 Homepage = "https://github.com/sunhailin-Leo/fastapi_profiler"
 Repository = "https://github.com/sunhailin-Leo/fastapi_profiler"
@@ -44,6 +47,11 @@ dev = [
     "flake8",
     "ruff",
     "ty",
+    # memray is included so the full memray lifecycle code path is exercised
+    # by `make test`.  It still ships as an *optional* runtime extra
+    # ([project.optional-dependencies].memray) so end users only install it
+    # when they need native allocation tracing.
+    "memray>=1.10.0; sys_platform != 'win32'",
 ]
 example = [
     "starlette",
@@ -85,6 +93,8 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # dashboard.py contains inlined HTML/CSS/JS that cannot be line-wrapped
 "fastapi_profiler/dashboard.py" = ["E501"]
+# memory_dashboard.py also contains inlined HTML/CSS for the memory UI page
+"fastapi_profiler/memory_dashboard.py" = ["E501"]
 # test files allow longer lines for readability (assertions, docstrings)
 "test/*.py" = ["E501"]
 # stats.py has a few unavoidably long lines in docstrings/dicts
@@ -108,6 +118,8 @@ per-file-ignores = [
     "fastapi_profiler/dashboard.py:E501",
     "fastapi_profiler/stats.py:E501",
     "fastapi_profiler/profiler.py:E501",
+    "fastapi_profiler/memory_dashboard.py:E501",
+    "fastapi_profiler/memory_middleware.py:E501",
     "test/*.py:E501",
 ]
 

--- a/test/test_memory.py
+++ b/test/test_memory.py
@@ -1,0 +1,508 @@
+"""Unit tests for the memory profiler sub-package and middleware."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import tracemalloc
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fastapi_profiler import (
+    MEMRAY_AVAILABLE,
+    MemoryProfilerMiddleware,
+    MemrayProfiler,
+    TracemallocProfiler,
+)
+from fastapi_profiler.memory.memray_profiler import (
+    IS_WINDOWS,
+    MemrayUnavailableError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def snapshot_dir():
+    """Provide a clean temporary directory for snapshot files."""
+    path = tempfile.mkdtemp(prefix="fp-mem-test-")
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture
+def stopped_tracemalloc():
+    """Ensure tracemalloc is stopped before and after the test."""
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+    yield
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+
+
+def make_app(snapshot_dir: str, **kwargs) -> tuple:
+    """Create a FastAPI app with MemoryProfilerMiddleware mounted."""
+    app = FastAPI()
+    app.add_middleware(
+        MemoryProfilerMiddleware,
+        server_app=app,
+        snapshot_dir=snapshot_dir,
+        **kwargs,
+    )
+
+    @app.get("/test")
+    async def normal_request():
+        return {"ok": True}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# TracemallocProfiler unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTracemallocProfilerLifecycle:
+    def test_start_stop_status(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        assert profiler.is_running() is False
+
+        result = profiler.start(frames=10)
+        assert result["running"] is True
+        assert result["frames"] == 10
+        assert profiler.is_running() is True
+
+        status = profiler.status()
+        assert status["running"] is True
+        assert status["frames"] == 10
+        assert status["snapshot_count"] == 0
+
+        stop_result = profiler.stop()
+        assert stop_result["running"] is False
+        assert profiler.is_running() is False
+
+    def test_double_start_is_noop(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start(frames=5)
+        result = profiler.start(frames=99)  # Should not change frames.
+        assert result["message"] == "already running"
+        assert profiler.status()["frames"] == 5
+        profiler.stop()
+
+    def test_stop_when_not_running(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        result = profiler.stop()
+        assert result["running"] is False
+        assert result["message"] == "not running"
+
+    def test_invalid_frames_rejected(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        with pytest.raises(ValueError):
+            profiler.start(frames=0)
+
+
+class TestTracemallocSnapshot:
+    def test_snapshot_requires_running(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        with pytest.raises(RuntimeError):
+            profiler.snapshot()
+
+    def test_snapshot_writes_file(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start(frames=5)
+        try:
+            # Allocate something so the snapshot has content.
+            payload = ["x" * 128 for _ in range(500)]
+            assert payload  # keep ref alive
+
+            result = profiler.snapshot(top=5)
+            assert "snapshot_id" in result
+            assert os.path.isfile(result["file_path"])
+            assert result["file_path"].endswith(".snap")
+            assert result["traced_memory_current_bytes"] >= 0
+            assert isinstance(result["top"], list)
+            assert len(result["top"]) <= 5
+        finally:
+            profiler.stop()
+
+    def test_snapshot_invalid_top_rejected(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            with pytest.raises(ValueError):
+                profiler.snapshot(top=0)
+        finally:
+            profiler.stop()
+
+    def test_list_snapshots_tracks_history(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            profiler.snapshot()
+            profiler.snapshot()
+            entries = profiler.list_snapshots()
+            assert len(entries) == 2
+            assert all("snapshot_id" in e and "file_path" in e for e in entries)
+        finally:
+            profiler.stop()
+
+    def test_stop_clears_snapshot_state(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        profiler.snapshot()
+        profiler.stop()
+        assert profiler.list_snapshots() == []
+
+
+class TestTracemallocCompare:
+    def test_compare_requires_two_snapshots(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            with pytest.raises(RuntimeError):
+                profiler.compare()
+            profiler.snapshot()
+            with pytest.raises(RuntimeError):
+                profiler.compare()
+        finally:
+            profiler.stop()
+
+    def test_compare_returns_top_growers(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            profiler.snapshot()
+            # Allocate something between snapshots to create a diff.
+            growth = ["y" * 256 for _ in range(2000)]
+            assert growth
+            profiler.snapshot()
+
+            result = profiler.compare(top=10)
+            assert "snapshot_a" in result
+            assert "snapshot_b" in result
+            assert isinstance(result["top"], list)
+            for entry in result["top"]:
+                assert "size_diff_bytes" in entry
+                assert "count_diff" in entry
+        finally:
+            profiler.stop()
+
+    def test_compare_unknown_id_raises(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            profiler.snapshot()
+            profiler.snapshot()
+            with pytest.raises(KeyError):
+                profiler.compare(snapshot_a="bogus", snapshot_b="also-bogus")
+        finally:
+            profiler.stop()
+
+    def test_compare_partial_ids_rejected(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            profiler.snapshot()
+            profiler.snapshot()
+            with pytest.raises(ValueError):
+                profiler.compare(snapshot_a="only-one")
+        finally:
+            profiler.stop()
+
+
+# ---------------------------------------------------------------------------
+# MemrayProfiler unit tests (degrade gracefully when memray is unavailable)
+# ---------------------------------------------------------------------------
+
+
+class TestMemrayAvailability:
+    def test_is_available_shape(self, snapshot_dir):
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        info = profiler.is_available()
+        assert "available" in info
+        assert "platform_supported" in info
+        assert "reason" in info
+
+    def test_status_includes_availability(self, snapshot_dir):
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        status = profiler.status()
+        assert "available" in status
+        assert status["running"] is False
+
+    def test_start_when_unavailable_raises(self, snapshot_dir):
+        if MEMRAY_AVAILABLE and not IS_WINDOWS:
+            pytest.skip("memray is available on this platform")
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        with pytest.raises(MemrayUnavailableError):
+            profiler.start()
+
+
+@pytest.mark.skipif(
+    not MEMRAY_AVAILABLE or IS_WINDOWS,
+    reason="memray is not available on this platform",
+)
+class TestMemrayLifecycle:
+    def test_start_stop_creates_bin(self, snapshot_dir):
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        result = profiler.start()
+        try:
+            assert result["running"] is True
+            assert result["output_path"].endswith(".bin")
+            assert profiler.is_running() is True
+        finally:
+            stop_result = profiler.stop()
+        assert stop_result["running"] is False
+        assert os.path.isfile(stop_result["output_path"])
+
+    def test_double_start_rejected(self, snapshot_dir):
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        profiler.start()
+        try:
+            with pytest.raises(RuntimeError):
+                profiler.start()
+        finally:
+            profiler.stop()
+
+    def test_stop_when_not_running(self, snapshot_dir):
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        result = profiler.stop()
+        assert result["running"] is False
+        assert result["message"] == "not running"
+
+
+# ---------------------------------------------------------------------------
+# HTTP control plane tests (via MemoryProfilerMiddleware)
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareMounting:
+    def test_index_returns_html(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.get("/__memory_profiler__/")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert "Memory Profiler" in response.text
+
+    def test_combined_status(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        data = client.get("/__memory_profiler__/status").json()
+        assert "tracemalloc" in data
+        assert "memray" in data
+        assert data["tracemalloc"]["running"] is False
+
+    def test_normal_request_passthrough(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.get("/test")
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+    def test_custom_dashboard_path(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir, memory_dashboard_path="/__mem__")
+        client = TestClient(app)
+        assert client.get("/__mem__/").status_code == 200
+        assert client.get("/__memory_profiler__/").status_code == 404
+
+    def test_warns_without_server_app(self, snapshot_dir, stopped_tracemalloc):
+        import warnings as _warnings
+
+        from starlette.applications import Starlette
+
+        plain_app = Starlette()
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            MemoryProfilerMiddleware(plain_app, snapshot_dir=snapshot_dir)
+        assert any(
+            "MemoryProfilerMiddleware requires server_app" in str(w.message)
+            for w in caught
+        )
+
+
+class TestTracemallocHTTP:
+    def test_full_lifecycle(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        base = "/__memory_profiler__/tracemalloc"
+
+        # Initially stopped.
+        assert client.get(f"{base}/status").json()["running"] is False
+
+        # Start.
+        start = client.post(f"{base}/start", json={"frames": 8}).json()
+        assert start["running"] is True
+        assert start["frames"] == 8
+
+        # Snapshot twice with allocations in between.
+        snap1 = client.post(f"{base}/snapshot", json={"top": 5}).json()
+        assert "snapshot_id" in snap1
+        _ = ["a" * 64 for _ in range(500)]
+        snap2 = client.post(f"{base}/snapshot").json()
+        assert snap1["snapshot_id"] != snap2["snapshot_id"]
+
+        # Compare.
+        compare = client.post(f"{base}/compare", json={"top": 5}).json()
+        assert "top" in compare
+        assert isinstance(compare["top"], list)
+
+        # List.
+        listing = client.get(f"{base}/snapshots").json()
+        assert len(listing["snapshots"]) == 2
+
+        # Stop.
+        stop = client.post(f"{base}/stop").json()
+        assert stop["running"] is False
+
+    def test_snapshot_before_start_returns_409(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post("/__memory_profiler__/tracemalloc/snapshot")
+        assert response.status_code == 409
+        assert "error" in response.json()
+
+    def test_compare_without_snapshots_returns_409(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            response = client.post("/__memory_profiler__/tracemalloc/compare")
+            assert response.status_code == 409
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+    def test_invalid_frames_returns_400(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/start",
+            json={"frames": 0},
+        )
+        assert response.status_code == 400
+
+    def test_invalid_top_returns_400(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            response = client.post(
+                "/__memory_profiler__/tracemalloc/snapshot",
+                json={"top": "huge"},
+            )
+            assert response.status_code == 400
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+    def test_invalid_json_body_returns_400(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/start",
+            content=b"not-json",
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 400
+
+    def test_compare_unknown_snapshot_returns_404(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            client.post("/__memory_profiler__/tracemalloc/snapshot")
+            client.post("/__memory_profiler__/tracemalloc/snapshot")
+            response = client.post(
+                "/__memory_profiler__/tracemalloc/compare",
+                json={"snapshot_a": "nope", "snapshot_b": "also-nope"},
+            )
+            assert response.status_code == 404
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+
+class TestMemrayHTTP:
+    def test_status_endpoint(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        data = client.get("/__memory_profiler__/memray/status").json()
+        assert "available" in data
+        assert "platform_supported" in data
+
+    def test_start_when_unavailable_returns_503(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        if MEMRAY_AVAILABLE and not IS_WINDOWS:
+            pytest.skip("memray is available; this test is for the unavailable path")
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post("/__memory_profiler__/memray/start")
+        assert response.status_code == 503
+        body = response.json()
+        assert "error" in body
+        assert "availability" in body
+
+    @pytest.mark.skipif(
+        not MEMRAY_AVAILABLE or IS_WINDOWS,
+        reason="memray is not available on this platform",
+    )
+    def test_full_lifecycle(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        start = client.post(
+            "/__memory_profiler__/memray/start",
+            json={"native": False, "follow_fork": False},
+        )
+        assert start.status_code == 200
+        try:
+            client.get("/test")  # generate some allocations
+        finally:
+            stop = client.post("/__memory_profiler__/memray/stop").json()
+        assert stop["running"] is False
+        assert os.path.isfile(stop["output_path"])
+
+    def test_invalid_bool_field_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/memray/start",
+            json={"native": "yes"},
+        )
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# autostart_tracemalloc behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAutostart:
+    def test_autostart_starts_tracemalloc(self, snapshot_dir, stopped_tracemalloc):
+        app = FastAPI()
+        app.add_middleware(
+            MemoryProfilerMiddleware,
+            server_app=app,
+            snapshot_dir=snapshot_dir,
+            autostart_tracemalloc=True,
+        )
+        # add_middleware defers wrapping until first request; force it.
+        client = TestClient(app)
+        client.get("/__memory_profiler__/status")
+        try:
+            assert tracemalloc.is_tracing() is True
+        finally:
+            if tracemalloc.is_tracing():
+                tracemalloc.stop()

--- a/test/test_memory_coverage.py
+++ b/test/test_memory_coverage.py
@@ -688,6 +688,10 @@ class TestDashboardExceptionMapping:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    IS_WINDOWS,
+    reason="memray is not supported on Windows; import always fails natively",
+)
 class TestMemrayImportFailureBranch:
     def test_import_failure_sets_flags(self, tmp_path):
         """Spawn a subprocess where ``import memray`` is forced to fail."""

--- a/test/test_memory_coverage.py
+++ b/test/test_memory_coverage.py
@@ -1,0 +1,977 @@
+"""Targeted tests to maximise coverage of the memory profiler modules.
+
+This file complements ``test/test_memory.py``.  It focuses on exception
+branches, the shutdown hook, the ``get_shutdown_handler`` accessor and a
+few edge cases of the JSON dashboard router that are awkward to express
+in the high-level lifecycle tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import tracemalloc
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fastapi_profiler import (
+    MEMRAY_AVAILABLE,
+    MemoryProfilerMiddleware,
+    MemrayProfiler,
+    TracemallocProfiler,
+)
+from fastapi_profiler.memory import memray_profiler as memray_module
+from fastapi_profiler.memory.memray_profiler import (
+    IS_WINDOWS,
+    MemrayUnavailableError,
+)
+from fastapi_profiler.memory.tracemalloc_profiler import _format_statistics
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def snapshot_dir():
+    path = tempfile.mkdtemp(prefix="fp-mem-cov-")
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture
+def stopped_tracemalloc():
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+    yield
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+
+
+def make_app(snapshot_dir: str, **kwargs) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        MemoryProfilerMiddleware,
+        server_app=app,
+        snapshot_dir=snapshot_dir,
+        **kwargs,
+    )
+
+    @app.get("/test")
+    async def _ok():
+        return {"ok": True}
+
+    return app
+
+
+def _run(coro):
+    """Run an async coroutine in a freshly-created event loop."""
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# tracemalloc edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestTracemallocFormatStatistics:
+    def test_format_statistics_handles_missing_traceback(self):
+        """Statistic with empty traceback should yield <unknown>:0."""
+        fake = MagicMock()
+        fake.traceback = []
+        fake.size = 100
+        fake.count = 2
+
+        out = _format_statistics([fake], top_n=5)
+        assert len(out) == 1
+        assert out[0]["file"] == "<unknown>"
+        assert out[0]["line"] == 0
+        assert out[0]["traceback"] == []
+
+    def test_format_statistics_diff_includes_diff_fields(self):
+        frame = MagicMock(filename="/tmp/x.py", lineno=42)
+        fake = MagicMock()
+        fake.traceback = [frame]
+        fake.size = 200
+        fake.count = 3
+        fake.size_diff = 150
+        fake.count_diff = 1
+
+        out = _format_statistics([fake], top_n=5, is_diff=True)
+        assert out[0]["size_diff_bytes"] == 150
+        assert out[0]["count_diff"] == 1
+
+
+class TestTracemallocCompareEdgeCases:
+    def test_compare_with_invalid_top_rejected(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            profiler.snapshot()
+            profiler.snapshot()
+            with pytest.raises(ValueError):
+                profiler.compare(top=0)
+        finally:
+            profiler.stop()
+
+
+# ---------------------------------------------------------------------------
+# memray availability branches (work regardless of memray install state)
+# ---------------------------------------------------------------------------
+
+
+class TestMemrayAvailabilityBranches:
+    def test_windows_branch_reported_as_unsupported(
+        self, snapshot_dir, monkeypatch
+    ):
+        """When IS_WINDOWS=True, is_available reports platform_supported=False."""
+        monkeypatch.setattr(memray_module, "IS_WINDOWS", True)
+        info = MemrayProfiler(output_dir=snapshot_dir).is_available()
+        assert info["available"] is False
+        assert info["platform_supported"] is False
+        assert "Windows" in info["reason"]
+
+    def test_missing_module_branch(self, snapshot_dir, monkeypatch):
+        """When MEMRAY_AVAILABLE=False (and not Windows) the install hint is returned."""
+        monkeypatch.setattr(memray_module, "IS_WINDOWS", False)
+        monkeypatch.setattr(memray_module, "MEMRAY_AVAILABLE", False)
+        monkeypatch.setattr(
+            memray_module, "_MEMRAY_IMPORT_ERROR", "ModuleNotFoundError: memray"
+        )
+        info = MemrayProfiler(output_dir=snapshot_dir).is_available()
+        assert info["available"] is False
+        assert info["platform_supported"] is True
+        assert "fastapi_profiler[memray]" in info["reason"]
+        assert "import_error" in info
+
+    def test_status_when_unavailable_includes_reason(
+        self, snapshot_dir, monkeypatch
+    ):
+        monkeypatch.setattr(memray_module, "IS_WINDOWS", False)
+        monkeypatch.setattr(memray_module, "MEMRAY_AVAILABLE", False)
+        status = MemrayProfiler(output_dir=snapshot_dir).status()
+        assert status["available"] is False
+        assert "reason" in status
+        assert status["running"] is False
+
+
+# ---------------------------------------------------------------------------
+# memray exception path: tracker.__enter__ raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not MEMRAY_AVAILABLE or IS_WINDOWS,
+    reason="memray must be available to exercise the failure-rollback branch",
+)
+class TestMemrayStartFailureRollback:
+    def test_tracker_enter_failure_rolls_back_state(
+        self, snapshot_dir, monkeypatch
+    ):
+        """If Tracker.__enter__ raises, profiler state must remain clean."""
+
+        class _BoomTracker:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                raise RuntimeError("boom")
+
+            def __exit__(self, exc_type, exc, tb):  # pragma: no cover - never reached
+                return False
+
+        monkeypatch.setattr(memray_module.memray, "Tracker", _BoomTracker)
+
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        with pytest.raises(RuntimeError, match="boom"):
+            profiler.start()
+
+        # State must be fully reset so a subsequent start() works.
+        assert profiler.is_running() is False
+        status = profiler.status()
+        assert status["running"] is False
+        assert "session_id" not in status
+
+
+# ---------------------------------------------------------------------------
+# memray full lifecycle (only when memray is available locally)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not MEMRAY_AVAILABLE or IS_WINDOWS,
+    reason="memray is not installed in this environment",
+)
+class TestMemrayStatusWhileRunning:
+    def test_status_running_includes_session_fields(self, snapshot_dir):
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        profiler.start()
+        try:
+            status = profiler.status()
+            assert status["running"] is True
+            assert "session_id" in status
+            assert "output_path" in status
+            assert "started_at" in status
+            assert status["running_seconds"] >= 0
+        finally:
+            profiler.stop()
+
+    def test_stop_returns_hint_with_path(self, snapshot_dir):
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        profiler.start()
+        result = profiler.stop()
+        assert result["hint"] is not None
+        assert "memray flamegraph" in result["hint"]
+        assert result["file_size_bytes"] > 0
+
+    def test_explicit_output_path_is_used(self, snapshot_dir):
+        explicit = os.path.join(snapshot_dir, "explicit.bin")
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        result = profiler.start(output_path=explicit)
+        try:
+            assert result["output_path"] == explicit
+        finally:
+            stop = profiler.stop()
+        assert stop["output_path"] == explicit
+        assert os.path.isfile(explicit)
+
+
+# ---------------------------------------------------------------------------
+# Dashboard router error branches
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardErrorBranches:
+    def test_tracemalloc_compare_invalid_snapshot_a_type(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            client.post("/__memory_profiler__/tracemalloc/snapshot")
+            client.post("/__memory_profiler__/tracemalloc/snapshot")
+            response = client.post(
+                "/__memory_profiler__/tracemalloc/compare",
+                json={"snapshot_a": 123, "snapshot_b": "ok"},
+            )
+            assert response.status_code == 400
+            assert "snapshot_a" in response.json()["error"]
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+    def test_tracemalloc_compare_invalid_snapshot_b_type(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            client.post("/__memory_profiler__/tracemalloc/snapshot")
+            client.post("/__memory_profiler__/tracemalloc/snapshot")
+            response = client.post(
+                "/__memory_profiler__/tracemalloc/compare",
+                json={"snapshot_a": "ok", "snapshot_b": 456},
+            )
+            assert response.status_code == 400
+            assert "snapshot_b" in response.json()["error"]
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+    def test_tracemalloc_compare_invalid_top_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            response = client.post(
+                "/__memory_profiler__/tracemalloc/compare",
+                json={"top": "huge"},
+            )
+            assert response.status_code == 400
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+    def test_tracemalloc_compare_zero_top_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            response = client.post(
+                "/__memory_profiler__/tracemalloc/compare",
+                json={"top": 0},
+            )
+            assert response.status_code == 400
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+    def test_tracemalloc_snapshot_zero_top_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            response = client.post(
+                "/__memory_profiler__/tracemalloc/snapshot",
+                json={"top": 0},
+            )
+            assert response.status_code == 400
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+    def test_tracemalloc_start_non_int_frames_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/start",
+            json={"frames": "many"},
+        )
+        assert response.status_code == 400
+
+    def test_json_body_must_be_object(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/start",
+            content=b"[1, 2, 3]",
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 400
+        assert "object" in response.json()["error"]
+
+    def test_memray_invalid_output_path_type_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/memray/start",
+            json={"output_path": 12345},
+        )
+        assert response.status_code == 400
+        assert "output_path" in response.json()["error"]
+
+    def test_memray_invalid_json_body_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/memray/start",
+            content=b"not-json",
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.skipif(
+    not MEMRAY_AVAILABLE or IS_WINDOWS,
+    reason="requires memray to exercise the 409 already-running branch",
+)
+class TestMemrayDoubleStartViaHTTP:
+    def test_starting_twice_returns_409(self, snapshot_dir, stopped_tracemalloc):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        first = client.post("/__memory_profiler__/memray/start")
+        try:
+            assert first.status_code == 200
+            second = client.post("/__memory_profiler__/memray/start")
+            assert second.status_code == 409
+        finally:
+            client.post("/__memory_profiler__/memray/stop")
+
+
+# ---------------------------------------------------------------------------
+# MemoryProfilerMiddleware: shutdown hook + accessors
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareAccessors:
+    def test_property_accessors_return_inner_profilers(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = FastAPI()
+        mw = MemoryProfilerMiddleware(
+            app,
+            server_app=app,
+            snapshot_dir=snapshot_dir,
+            memory_dashboard_path="/__mem__",
+        )
+        assert isinstance(mw.tracemalloc_profiler, TracemallocProfiler)
+        assert isinstance(mw.memray_profiler, MemrayProfiler)
+        assert mw.dashboard_path == "/__mem__"
+        # bound methods compare equal even when not identity-equal.
+        handler = mw.get_shutdown_handler()
+        assert handler is not None
+        assert handler == mw._on_shutdown
+        assert asyncio.iscoroutinefunction(handler)
+
+    def test_dashboard_path_normalisation(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        """Trailing slashes are stripped; empty path falls back to default."""
+        app = FastAPI()
+        mw = MemoryProfilerMiddleware(
+            app,
+            server_app=app,
+            snapshot_dir=snapshot_dir,
+            memory_dashboard_path="/__mem__/",
+        )
+        assert mw.dashboard_path == "/__mem__"
+
+        app2 = FastAPI()
+        mw2 = MemoryProfilerMiddleware(
+            app2,
+            server_app=app2,
+            snapshot_dir=snapshot_dir,
+            memory_dashboard_path="/",
+        )
+        assert mw2.dashboard_path == MemoryProfilerMiddleware.DEFAULT_PATH
+
+
+class TestMiddlewareShutdownHook:
+    def test_shutdown_stops_running_tracemalloc(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = FastAPI()
+        mw = MemoryProfilerMiddleware(
+            app, server_app=app, snapshot_dir=snapshot_dir
+        )
+        mw.tracemalloc_profiler.start(frames=5)
+        assert tracemalloc.is_tracing() is True
+
+        _run(mw._on_shutdown())
+        assert tracemalloc.is_tracing() is False
+
+    def test_shutdown_when_nothing_running_is_noop(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = FastAPI()
+        mw = MemoryProfilerMiddleware(
+            app, server_app=app, snapshot_dir=snapshot_dir
+        )
+        # Should not raise even when neither profiler is active.
+        _run(mw._on_shutdown())
+
+    def test_shutdown_swallows_tracemalloc_errors(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = FastAPI()
+        mw = MemoryProfilerMiddleware(
+            app, server_app=app, snapshot_dir=snapshot_dir
+        )
+        # Force is_running to True but make stop() raise.
+        with patch.object(
+            mw._tracemalloc, "is_running", return_value=True
+        ), patch.object(
+            mw._tracemalloc, "stop", side_effect=RuntimeError("boom")
+        ):
+            # Must not propagate.
+            _run(mw._on_shutdown())
+
+    def test_shutdown_swallows_memray_errors(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = FastAPI()
+        mw = MemoryProfilerMiddleware(
+            app, server_app=app, snapshot_dir=snapshot_dir
+        )
+        with patch.object(
+            mw._memray, "is_running", return_value=True
+        ), patch.object(
+            mw._memray, "stop", side_effect=RuntimeError("kaboom")
+        ):
+            _run(mw._on_shutdown())
+
+    @pytest.mark.skipif(
+        not MEMRAY_AVAILABLE or IS_WINDOWS,
+        reason="memray needed to truly stop a running session",
+    )
+    def test_shutdown_finalises_running_memray(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = FastAPI()
+        mw = MemoryProfilerMiddleware(
+            app, server_app=app, snapshot_dir=snapshot_dir
+        )
+        mw.memray_profiler.start()
+        assert mw.memray_profiler.is_running() is True
+        _run(mw._on_shutdown())
+        assert mw.memray_profiler.is_running() is False
+
+
+class TestAutostartWithoutServerApp:
+    def test_warns_and_still_autostarts(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        """server_app=None still allows autostart_tracemalloc to run."""
+        import warnings as _warnings
+
+        from starlette.applications import Starlette
+
+        plain_app = Starlette()
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            mw = MemoryProfilerMiddleware(
+                plain_app,
+                snapshot_dir=snapshot_dir,
+                autostart_tracemalloc=True,
+            )
+        try:
+            assert any(
+                "MemoryProfilerMiddleware requires server_app" in str(w.message)
+                for w in caught
+            )
+            assert mw.tracemalloc_profiler.is_running() is True
+        finally:
+            mw.tracemalloc_profiler.stop()
+
+
+# ---------------------------------------------------------------------------
+# tracemalloc HTTP: status while running exposes traced_memory_*
+# ---------------------------------------------------------------------------
+
+
+class TestTracemallocStatusFields:
+    def test_status_running_exposes_traced_memory(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start", json={"frames": 4})
+        try:
+            data = client.get("/__memory_profiler__/tracemalloc/status").json()
+            assert data["running"] is True
+            assert data["frames"] == 4
+            assert data["traced_memory_current_bytes"] >= 0
+            assert data["traced_memory_peak_bytes"] >= 0
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+
+# ---------------------------------------------------------------------------
+# Patched dashboard error-mapping branches
+#
+# A few exception → HTTP status mappings in memory_dashboard.py are hard to
+# reach in normal lifecycle tests because the underlying profiler does not
+# raise from the corresponding code paths.  We patch the profilers to raise
+# deterministically so each ``except`` branch is exercised.
+# ---------------------------------------------------------------------------
+
+
+def _make_app_with_profilers(snapshot_dir, tm_profiler, mr_profiler):
+    """Build an app whose memory router uses externally-provided profilers."""
+    from fastapi_profiler.memory_dashboard import create_memory_router
+
+    app = FastAPI()
+    router = create_memory_router(
+        tracemalloc_profiler=tm_profiler,
+        memray_profiler=mr_profiler,
+    )
+    app.mount("/__memory_profiler__", app=router)
+    return app
+
+
+class _FakeTracemalloc:
+    """Minimal stand-in for TracemallocProfiler with controllable errors."""
+
+    def __init__(self):
+        self._snapshots = []
+
+    def status(self):
+        return {"running": False}
+
+    def start(self, frames=None):
+        # Force the dashboard's ``except ValueError`` branch.
+        raise ValueError("frames must be >= 1")
+
+    def stop(self):
+        return {"running": False}
+
+    def snapshot(self, top=None):
+        # Force the dashboard's ``except ValueError`` branch from snapshot().
+        raise ValueError("bogus top")
+
+    def compare(self, top=None, snapshot_a=None, snapshot_b=None):
+        # Force the dashboard's ``except ValueError`` branch from compare().
+        raise ValueError("snapshots must both be set")
+
+    def list_snapshots(self):
+        return []
+
+
+class TestDashboardExceptionMapping:
+    def test_tm_start_value_error_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        real_mr = MemrayProfiler(output_dir=snapshot_dir)
+        app = _make_app_with_profilers(snapshot_dir, _FakeTracemalloc(), real_mr)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/start", json={"frames": 5}
+        )
+        assert response.status_code == 400
+        assert "frames" in response.json()["error"]
+
+    def test_tm_snapshot_value_error_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        real_mr = MemrayProfiler(output_dir=snapshot_dir)
+        app = _make_app_with_profilers(snapshot_dir, _FakeTracemalloc(), real_mr)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/snapshot", json={"top": 5}
+        )
+        assert response.status_code == 400
+        assert "bogus" in response.json()["error"]
+
+    def test_tm_compare_value_error_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        real_mr = MemrayProfiler(output_dir=snapshot_dir)
+        app = _make_app_with_profilers(snapshot_dir, _FakeTracemalloc(), real_mr)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/compare", json={"top": 5}
+        )
+        assert response.status_code == 400
+        assert "must both" in response.json()["error"]
+
+    def test_tm_compare_keyerror_returns_404(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        """Two known snapshots + one bogus id triggers KeyError → 404."""
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            snap1 = client.post(
+                "/__memory_profiler__/tracemalloc/snapshot"
+            ).json()
+            client.post("/__memory_profiler__/tracemalloc/snapshot")
+            response = client.post(
+                "/__memory_profiler__/tracemalloc/compare",
+                json={
+                    "snapshot_a": snap1["snapshot_id"],
+                    "snapshot_b": "definitely-not-a-real-id",
+                },
+            )
+            assert response.status_code == 404
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+
+# ---------------------------------------------------------------------------
+# memray import-failure branch (lines 39-42)
+#
+# We can't easily un-import memray after pytest started, but we *can* run
+# the whole memray_profiler module in a subprocess where memray is hidden
+# via PYTHONPATH manipulation.  That executes the import-failure branch
+# inside a fresh Python process and reports the result.
+# ---------------------------------------------------------------------------
+
+
+class TestMemrayImportFailureBranch:
+    def test_import_failure_sets_flags(self, tmp_path):
+        """Spawn a subprocess where ``import memray`` is forced to fail."""
+        import subprocess
+        import textwrap
+
+        # Create a fake `memray` package that raises on import to trigger the
+        # except-branch in fastapi_profiler.memory.memray_profiler.
+        fake_pkg_dir = tmp_path / "fake-memray"
+        fake_pkg_dir.mkdir()
+        (fake_pkg_dir / "memray.py").write_text(
+            "raise ImportError('forced failure for coverage')\n"
+        )
+
+        # Minimal driver script.  Prepending fake_pkg_dir ensures the bogus
+        # `memray` shadows the real one.  Then we re-import the profiler
+        # module *fresh* and assert it captured the import failure.
+        driver = textwrap.dedent(
+            f"""
+            import sys
+            sys.path.insert(0, {str(fake_pkg_dir)!r})
+            # Make sure neither ``memray`` nor the profiler module is cached.
+            for mod in list(sys.modules):
+                if mod == 'memray' or mod.startswith(
+                    'fastapi_profiler.memory.memray_profiler'
+                ):
+                    sys.modules.pop(mod, None)
+
+            from fastapi_profiler.memory import memray_profiler as m
+            assert m.MEMRAY_AVAILABLE is False, m.MEMRAY_AVAILABLE
+            assert m.memray is None
+            assert 'forced failure' in (m._MEMRAY_IMPORT_ERROR or '')
+
+            # Also verify is_available + _require_available behave correctly.
+            info = m.MemrayProfiler(output_dir='/tmp').is_available()
+            assert info['available'] is False
+            assert 'fastapi_profiler[memray]' in info['reason']
+            print('OK')
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", driver],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"subprocess failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "OK" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# memray stop() branches: started_at=None edge (line 255 area)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not MEMRAY_AVAILABLE or IS_WINDOWS,
+    reason="memray needed to manipulate internal state",
+)
+class TestMemrayStopEdgeCases:
+    def test_stop_with_missing_started_at(self, snapshot_dir):
+        """Defensive branch: started_at=None → duration_seconds == 0.0."""
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        profiler.start()
+        # Pretend the timestamp got lost (defensive code path).
+        profiler._started_at = None
+        result = profiler.stop()
+        assert result["running"] is False
+        assert result["duration_seconds"] == 0.0
+
+    def test_stop_with_missing_output_path(self, snapshot_dir):
+        """When output path is gone, file_size_bytes falls back to 0."""
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        profiler.start()
+        # Force the "no file on disk" branch.
+        profiler._current_output = "/nonexistent/path/does-not-exist.bin"
+        result = profiler.stop()
+        assert result["file_size_bytes"] == 0
+        assert "memray flamegraph" in (result["hint"] or "")
+
+
+# ---------------------------------------------------------------------------
+# memray _require_available raise branch (line 255)
+# ---------------------------------------------------------------------------
+
+
+class TestMemrayRequireAvailableRaises:
+    def test_require_available_raises_when_unavailable(
+        self, snapshot_dir, monkeypatch
+    ):
+        """Force is_available=False so _require_available raises."""
+        monkeypatch.setattr(memray_module, "MEMRAY_AVAILABLE", False)
+        monkeypatch.setattr(memray_module, "IS_WINDOWS", False)
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+        with pytest.raises(MemrayUnavailableError):
+            profiler._require_available()
+
+    def test_require_available_with_empty_reason(
+        self, snapshot_dir, monkeypatch
+    ):
+        """If is_available returns reason=None for the not-available branch,
+        _require_available must still raise with a default message."""
+        profiler = MemrayProfiler(output_dir=snapshot_dir)
+
+        def fake_is_available():
+            return {
+                "available": False,
+                "platform_supported": True,
+                "reason": None,
+            }
+
+        monkeypatch.setattr(profiler, "is_available", fake_is_available)
+        with pytest.raises(MemrayUnavailableError, match="memray unavailable"):
+            profiler._require_available()
+
+
+# ---------------------------------------------------------------------------
+# Dashboard _read_json_body / helper coverage (lines 98-100, 170-171, 192-193, 257)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMemrayUnavailable:
+    """Stand-in MemrayProfiler whose start() raises MemrayUnavailableError.
+
+    Used so the dashboard's ``except MemrayUnavailableError`` branch (which
+    is not reachable via ``make_app`` when memray is installed) can be hit
+    deterministically.
+    """
+
+    def status(self):
+        return {"available": False, "running": False}
+
+    def is_available(self):
+        return {
+            "available": False,
+            "platform_supported": True,
+            "reason": "stubbed unavailable",
+        }
+
+    def start(self, output_path=None, **kwargs):
+        raise MemrayUnavailableError("stubbed unavailable")
+
+    def stop(self):
+        return {"running": False, "message": "not running"}
+
+
+class _FakeMemrayAlreadyRunning:
+    """Stand-in MemrayProfiler whose start() raises RuntimeError (already running)."""
+
+    def status(self):
+        return {"available": True, "running": True}
+
+    def is_available(self):
+        return {"available": True, "platform_supported": True, "reason": None}
+
+    def start(self, output_path=None, **kwargs):
+        raise RuntimeError("memray tracker already running; call stop() first")
+
+    def stop(self):
+        return {"running": False}
+
+
+class TestDashboardMemrayBranches:
+    def test_memray_unavailable_returns_503(self, snapshot_dir, stopped_tracemalloc):
+        real_tm = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        app = _make_app_with_profilers(snapshot_dir, real_tm, _FakeMemrayUnavailable())
+        client = TestClient(app)
+        response = client.post("/__memory_profiler__/memray/start")
+        assert response.status_code == 503
+        body = response.json()
+        assert "stubbed unavailable" in body["error"]
+        assert body["availability"]["available"] is False
+
+    def test_memray_runtime_error_returns_409(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        real_tm = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        app = _make_app_with_profilers(
+            snapshot_dir, real_tm, _FakeMemrayAlreadyRunning()
+        )
+        client = TestClient(app)
+        response = client.post("/__memory_profiler__/memray/start")
+        assert response.status_code == 409
+        assert "already running" in response.json()["error"]
+
+
+class TestDashboardJsonBodyHelper:
+    """Directly exercise _read_json_body's branches via Starlette's TestClient.
+
+    Each test posts a deliberately-malformed body to a route that calls
+    ``_read_json_body``; the resulting 400 / 200 confirms which branch ran.
+    """
+
+    def test_empty_body_returns_none_branch(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        """Empty POST body → `_read_json_body` returns None → start succeeds."""
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        # No body, no Content-Type — exercises the ``if not raw: return None`` branch.
+        response = client.post("/__memory_profiler__/tracemalloc/start")
+        try:
+            assert response.status_code == 200
+            assert response.json()["running"] is True
+        finally:
+            client.post("/__memory_profiler__/tracemalloc/stop")
+
+    def test_non_object_body_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        """JSON array (not object) → ValueError → 400."""
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/snapshot",
+            content=b'"a-string"',
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 400
+        assert "object" in response.json()["error"]
+
+    def test_invalid_json_on_compare_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        """Invalid JSON on /tracemalloc/compare → 400."""
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/compare",
+            content=b"<not-json>",
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 400
+        assert "invalid JSON" in response.json()["error"]
+
+    def test_invalid_json_on_snapshot_returns_400(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        """Invalid JSON on /tracemalloc/snapshot → 400."""
+        app = make_app(snapshot_dir)
+        client = TestClient(app)
+        response = client.post(
+            "/__memory_profiler__/tracemalloc/snapshot",
+            content=b"<not-json>",
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 400
+        assert "invalid JSON" in response.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# tracemalloc _resolve_pair_locked KeyError branch (lines 234-236)
+#
+# The dashboard test only triggers KeyError via the route (which strips the
+# message); here we exercise it directly to be explicit about the branch.
+# ---------------------------------------------------------------------------
+
+
+class TestTracemallocResolvePairKeyError:
+    def test_unknown_a_and_b_ids_raise(self, snapshot_dir, stopped_tracemalloc):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            profiler.snapshot()
+            profiler.snapshot()
+            with pytest.raises(KeyError):
+                profiler.compare(snapshot_a="missing-a", snapshot_b="missing-b")
+        finally:
+            profiler.stop()
+
+    def test_only_one_id_unknown_still_raises(
+        self, snapshot_dir, stopped_tracemalloc
+    ):
+        profiler = TracemallocProfiler(snapshot_dir=snapshot_dir)
+        profiler.start()
+        try:
+            snap1 = profiler.snapshot()
+            profiler.snapshot()
+            with pytest.raises(KeyError):
+                profiler.compare(
+                    snapshot_a=snap1["snapshot_id"],
+                    snapshot_b="missing-b",
+                )
+        finally:
+            profiler.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -668,13 +668,18 @@ wheels = [
 
 [[package]]
 name = "fastapi-profiler"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", version = "0.124.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "fastapi", version = "0.128.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "fastapi", version = "0.135.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyinstrument" },
+]
+
+[package.optional-dependencies]
+memray = [
+    { name = "memray", marker = "sys_platform != 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -686,6 +691,7 @@ dev = [
     { name = "flake8", version = "7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
     { name = "flake8", version = "7.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "httpx" },
+    { name = "memray", marker = "sys_platform != 'win32'" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -708,14 +714,17 @@ example = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi" },
+    { name = "memray", marker = "sys_platform != 'win32' and extra == 'memray'", specifier = ">=1.10.0" },
     { name = "pyinstrument", specifier = ">=4.4.0" },
 ]
+provides-extras = ["memray"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage" },
     { name = "flake8" },
     { name = "httpx" },
+    { name = "memray", marker = "sys_platform != 'win32'", specifier = ">=1.10.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "requests" },
@@ -854,6 +863,224 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe", version = "2.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "markupsafe", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "uc-micro-py", version = "1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "uc-micro-py", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py", version = "2.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+plugins = [
+    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "2.1.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b", size = 19384, upload-time = "2024-02-02T16:31:22.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/54/ad5eb37bf9d51800010a74e4665425831a9db4e7c4e0fde4352e391e808e/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc", size = 18206, upload-time = "2024-02-02T16:30:04.105Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4a/a4d49415e600bacae038c67f9fecc1d5433b9d3c71a4de6f33537b89654c/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5", size = 14079, upload-time = "2024-02-02T16:30:06.5Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46", size = 26620, upload-time = "2024-02-02T16:30:08.31Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f", size = 25818, upload-time = "2024-02-02T16:30:09.577Z" },
+    { url = "https://files.pythonhosted.org/packages/29/fe/a36ba8c7ca55621620b2d7c585313efd10729e63ef81e4e61f52330da781/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900", size = 25493, upload-time = "2024-02-02T16:30:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ae/9c60231cdfda003434e8bd27282b1f4e197ad5a710c14bee8bea8a9ca4f0/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff", size = 30630, upload-time = "2024-02-02T16:30:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/65/dc/1510be4d179869f5dafe071aecb3f1f41b45d37c02329dfba01ff59e5ac5/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad", size = 29745, upload-time = "2024-02-02T16:30:14.222Z" },
+    { url = "https://files.pythonhosted.org/packages/30/39/8d845dd7d0b0613d86e0ef89549bfb5f61ed781f59af45fc96496e897f3a/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd", size = 30021, upload-time = "2024-02-02T16:30:16.032Z" },
+    { url = "https://files.pythonhosted.org/packages/11/e7/291e55127bb2ae67c64d66cef01432b5933859dfb7d6949daa721b89d0b3/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f", size = 18219, upload-time = "2024-02-02T16:30:19.988Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/cb/aed7a284c00dfa7c0682d14df85ad4955a350a21d2e3b06d8240497359bf/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2", size = 14098, upload-time = "2024-02-02T16:30:21.063Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/35fe557e53709e93feb65575c93927942087e9b97213eabc3fe9d5b25a55/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced", size = 29014, upload-time = "2024-02-02T16:30:22.926Z" },
+    { url = "https://files.pythonhosted.org/packages/97/18/c30da5e7a0e7f4603abfc6780574131221d9148f323752c2755d48abad30/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5", size = 28220, upload-time = "2024-02-02T16:30:24.76Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/40/2e73e7d532d030b1e41180807a80d564eda53babaf04d65e15c1cf897e40/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c", size = 27756, upload-time = "2024-02-02T16:30:25.877Z" },
+    { url = "https://files.pythonhosted.org/packages/18/46/5dca760547e8c59c5311b332f70605d24c99d1303dd9a6e1fc3ed0d73561/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f", size = 33988, upload-time = "2024-02-02T16:30:26.935Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c5/27febe918ac36397919cd4a67d5579cbbfa8da027fa1238af6285bb368ea/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a", size = 32718, upload-time = "2024-02-02T16:30:28.111Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/81/56e567126a2c2bc2684d6391332e357589a96a76cb9f8e5052d85cb0ead8/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f", size = 33317, upload-time = "2024-02-02T16:30:29.214Z" },
+    { url = "https://files.pythonhosted.org/packages/53/bd/583bf3e4c8d6a321938c13f49d44024dbe5ed63e0a7ba127e454a66da974/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1", size = 18215, upload-time = "2024-02-02T16:30:33.081Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d6/e7cd795fc710292c3af3a06d80868ce4b02bfbbf370b7cee11d282815a2a/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4", size = 14069, upload-time = "2024-02-02T16:30:34.148Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b5/5d8ec796e2a08fc814a2c7d2584b55f889a55cf17dd1a90f2beb70744e5c/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee", size = 29452, upload-time = "2024-02-02T16:30:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/2454f072fae3b5a137c119abf15465d1771319dfe9e4acbb31722a0fff91/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5", size = 28462, upload-time = "2024-02-02T16:30:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/75/fd6cb2e68780f72d47e6671840ca517bda5ef663d30ada7616b0462ad1e3/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b", size = 27869, upload-time = "2024-02-02T16:30:37.834Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/81/147c477391c2750e8fc7705829f7351cf1cd3be64406edcf900dc633feb2/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a", size = 33906, upload-time = "2024-02-02T16:30:39.366Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ff/9a52b71839d7a256b563e85d11050e307121000dcebc97df120176b3ad93/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f", size = 32296, upload-time = "2024-02-02T16:30:40.413Z" },
+    { url = "https://files.pythonhosted.org/packages/88/07/2dc76aa51b481eb96a4c3198894f38b480490e834479611a4053fbf08623/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169", size = 33038, upload-time = "2024-02-02T16:30:42.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ff/2c942a82c35a49df5de3a630ce0a8456ac2969691b230e530ac12314364c/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a", size = 18192, upload-time = "2024-02-02T16:30:57.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/14/6f294b9c4f969d0c801a4615e221c1e084722ea6114ab2114189c5b8cbe0/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46", size = 14072, upload-time = "2024-02-02T16:30:58.844Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d4/fd74714ed30a1dedd0b82427c02fa4deec64f173831ec716da11c51a50aa/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532", size = 26928, upload-time = "2024-02-02T16:30:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/50319665ce81bb10e90d1cf76f9e1aa269ea6f7fa30ab4521f14d122a3df/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab", size = 26106, upload-time = "2024-02-02T16:31:01.582Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/6f/f2b0f675635b05f6afd5ea03c094557bdb8622fa8e673387444fe8d8e787/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68", size = 25781, upload-time = "2024-02-02T16:31:02.71Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e0/393467cf899b34a9d3678e78961c2c8cdf49fb902a959ba54ece01273fb1/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0", size = 30518, upload-time = "2024-02-02T16:31:04.392Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/02/5437e2ad33047290dafced9df741d9efc3e716b75583bbd73a9984f1b6f7/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4", size = 29669, upload-time = "2024-02-02T16:31:05.53Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7d/968284145ffd9d726183ed6237c77938c021abacde4e073020f920e060b2/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3", size = 29933, upload-time = "2024-02-02T16:31:06.636Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/31/780bb297db036ba7b7bbede5e1d7f1e14d704ad4beb3ce53fb495d22bc62/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf", size = 18193, upload-time = "2024-02-02T16:31:10.155Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/77/d77701bbef72892affe060cdacb7a2ed7fd68dae3b477a8642f15ad3b132/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2", size = 14073, upload-time = "2024-02-02T16:31:11.442Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a7/1e558b4f78454c8a3a0199292d96159eb4d091f983bc35ef258314fe7269/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8", size = 26486, upload-time = "2024-02-02T16:31:12.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5a/360da85076688755ea0cceb92472923086993e86b5613bbae9fbc14136b0/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3", size = 25685, upload-time = "2024-02-02T16:31:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/18/ae5a258e3401f9b8312f92b028c54d7026a97ec3ab20bfaddbdfa7d8cce8/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465", size = 25338, upload-time = "2024-02-02T16:31:14.812Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cc/48206bd61c5b9d0129f4d75243b156929b04c94c09041321456fd06a876d/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e", size = 30439, upload-time = "2024-02-02T16:31:15.946Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/06/a41c112ab9ffdeeb5f77bc3e331fdadf97fa65e52e44ba31880f4e7f983c/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea", size = 29531, upload-time = "2024-02-02T16:31:17.13Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8c/ab9a463301a50dab04d5472e998acbd4080597abc048166ded5c7aa768c8/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6", size = 29823, upload-time = "2024-02-02T16:31:18.247Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/56/23/0d8c13a44bde9154821586520840643467aee574d8ce79a17da539ee7fed/markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26", size = 11623, upload-time = "2025-09-27T18:37:29.296Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/23/07a2cb9a8045d5f3f0890a8c3bc0859d7a47bfd9a560b563899bec7b72ed/markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc", size = 12049, upload-time = "2025-09-27T18:37:30.234Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e4/6be85eb81503f8e11b61c0b6369b6e077dcf0a74adbd9ebf6b349937b4e9/markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c", size = 21923, upload-time = "2025-09-27T18:37:31.177Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/bc/4dc914ead3fe6ddaef035341fee0fc956949bbd27335b611829292b89ee2/markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42", size = 20543, upload-time = "2025-09-27T18:37:32.168Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/5fe81fbcfba4aef4093d5f856e5c774ec2057946052d18d168219b7bd9f9/markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b", size = 20585, upload-time = "2025-09-27T18:37:33.166Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f6/e0e5a3d3ae9c4020f696cd055f940ef86b64fe88de26f3a0308b9d3d048c/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758", size = 21387, upload-time = "2025-09-27T18:37:34.185Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/651753ef4dea08ea790f4fbb65146a9a44a014986996ca40102e237aa49a/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2", size = 20133, upload-time = "2025-09-27T18:37:35.138Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/0a/c3cf2b4fef5f0426e8a6d7fce3cb966a17817c568ce59d76b92a233fdbec/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d", size = 20588, upload-time = "2025-09-27T18:37:36.096Z" },
+]
+
+[[package]]
 name = "mccabe"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -863,12 +1090,153 @@ wheels = [
 ]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542, upload-time = "2024-09-09T20:27:49.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316, upload-time = "2024-09-09T20:27:48.397Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/3d/e0e8d9d1cee04f758120915e2b2a3a07eb41f8cf4654b4734788a522bcd1/mdit_py_plugins-0.6.0.tar.gz", hash = "sha256:2436f14a7295837ac9228a36feeabda867c4abc488c8d019ad5c0bda88eee040", size = 56025, upload-time = "2026-05-07T12:20:42.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d6/48f5b9e44e2e760855d7b489b1317cd7620e82dcb73197961e5cc1391348/mdit_py_plugins-0.6.0-py3-none-any.whl", hash = "sha256:f7e7a25d8b616fee99cb1e330da73451d11a8061baf39bb9663ab9ce0e005b90", size = 66655, upload-time = "2026-05-07T12:20:41.226Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "memray"
+version = "1.19.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "rich", version = "15.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "textual", version = "0.73.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
+    { name = "textual", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+    { name = "textual", version = "8.2.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/04/5b886a36df947599e0f37cd46e6e44e565299815f044e2303ab2ae9f8870/memray-1.19.3.tar.gz", hash = "sha256:4e0fb29ff0a50c0ec9dc84294d8f2c83419feba561a37628b304c2ae4fe73d03", size = 2417089, upload-time = "2026-04-08T18:49:32.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/9a/262e81a1c5dba8c024049cc0d4b72bf695b5be38f92eaed0f3d6a720cf4e/memray-1.19.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:e4a7885ab920df180e40c6dd29b6ac09a0d58d92055a2861372a9d50f9e02ab3", size = 2182755, upload-time = "2026-04-08T18:47:39.098Z" },
+    { url = "https://files.pythonhosted.org/packages/81/75/a4331a5ba7f545acfddd6ce8bf13493273adaf52a5b7356f83bac36449c5/memray-1.19.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:82ec3b737207ba0185e9a2e1cec775e648839b9ccd9a38cb95256270ea33dd43", size = 2160580, upload-time = "2026-04-08T18:47:41.112Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c3/aacfb92ac6b6fd382c4a409c6c65008b8d80f009ff5f306de0df99c61672/memray-1.19.3-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:8203b75c26117564a27b685317ad73cf82a335e643d254c60e0d20215f1461f2", size = 9722985, upload-time = "2026-04-08T18:47:43.244Z" },
+    { url = "https://files.pythonhosted.org/packages/40/07/34625d678f9ec222e90fadebe7612b1914e9efcc8d1e7477fe5ed84c8e5e/memray-1.19.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d66e842814a762d022b04d620cfd0a4ba3c6ad5a09148f031c795396c258819b", size = 9954029, upload-time = "2026-04-08T18:47:45.591Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/59/cb70f0664f89e6dd30f28a1280c117fa8dd758f0a9adbeadb8cabde3733c/memray-1.19.3-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507d0f6b1041a9e9966242aa7529212a8053a5c3e3bd02997e5f50a0b6dff637", size = 9341828, upload-time = "2026-04-08T18:47:47.825Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c7/502f279872554bd5eaec4c024b2bafc50f9e22d6e3259850a365e34d7226/memray-1.19.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1e9b975aebae3e1712508971719e4186d1039eb1e0677453ef63d87396526d1b", size = 12176485, upload-time = "2026-04-08T18:47:50.823Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/42/20f595239918edb3fd967f47df7b89d1b728c1d04f34c616b78f17e85305/memray-1.19.3-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:7919d48b8e6df45a1b332fae484a14d427619c123a254ca23468ec232bb4152b", size = 2183379, upload-time = "2026-04-08T18:47:52.846Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e7/8371761d845e126bbd3230e0137fc147db5f6c35cd6b6150b86ed80fe34b/memray-1.19.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d5b1484dd32752dd9a194571dbfe8de175ca7159f4b0a24efc7e954710ea0b0", size = 2161168, upload-time = "2026-04-08T18:47:54.614Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/15/5f87e8a2f73c6e7e79c48efbc9d5dd570ffd74754412115b6cd32c43f138/memray-1.19.3-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:c3e9d2c0172ff0419832a510ac6305504712bf268059cdfd6b4e948f6ba1ccf5", size = 9789479, upload-time = "2026-04-08T18:47:56.578Z" },
+    { url = "https://files.pythonhosted.org/packages/76/09/32caf5915b487a705fb7c41bfca5dfe65486995615143493e6b43773da8d/memray-1.19.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:96de36ae809eaf8484bdbd937ce890b3b206269f66a7e1dea004fd115a712d24", size = 10035022, upload-time = "2026-04-08T18:47:58.739Z" },
+    { url = "https://files.pythonhosted.org/packages/64/2a/e01de8c939018dd99dc61627c7a706f25bec6f1665f071a8482e888b3d76/memray-1.19.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bf98ffa7b022ddbac8b832a2c4e63e2a7f67d0c69d38b1712bc3347e7066b", size = 9414903, upload-time = "2026-04-08T18:48:00.888Z" },
+    { url = "https://files.pythonhosted.org/packages/38/09/ca69127bba2ecd5d2a9b62de06846c91d46dacb814d329deaf09e601dd7f/memray-1.19.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b49362844937831dc0f324fbad28cfd1cd7006a1e8dc1e950891a3b9cc02dcc4", size = 12252069, upload-time = "2026-04-08T18:48:03.563Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/79/095c09f62f2ca527e4b5e71c38e7c9686f06c15a39f69f691428c45bae83/memray-1.19.3-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:dcbfa513332366544a2fdc74f0e385f3a11a2233ca9de5aac986e396ce0a2293", size = 2185040, upload-time = "2026-04-08T18:48:05.98Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/26/8328966c9b1cecbf43e8c96a210178f68fb1df8a62dd4f1735158aa6610b/memray-1.19.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4df9b00262fe48485c2afc4a52c88640d729d3bf999b3c633052d40c0ee970d1", size = 2163887, upload-time = "2026-04-08T18:48:07.455Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/eb/6ed7c46c2e6aec4d18926662114e88ba557f2e88c50fd5737b7989d67f3c/memray-1.19.3-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4a710509a5728a6f3b79eca615b538f9fa20452b21c0ba5265bdfb5fd4ff5f1d", size = 9743964, upload-time = "2026-04-08T18:48:09.213Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/60/668ad1dd30744564ef2d3e444bf39e10c41f1820240e949d0a3fadea9101/memray-1.19.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:578349f78268d2561275c4fb78c7ebe215f5264ad408d46207795ae58ec5d79e", size = 10013567, upload-time = "2026-04-08T18:48:11.513Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/aa/e5e969d50e57ef3ae41c6996626381afe3c9933d1924844d326f05240596/memray-1.19.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbbe64058ea329e7ff4f2c8067e6400b7db7d44a3f897a36c21f1a54e9b0c1ee", size = 9387646, upload-time = "2026-04-08T18:48:13.803Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ea/b23b30e31f365687004df304b9e46f19de4f5b860e78b363dd5d51f618f9/memray-1.19.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1a60d44b18ac5c1f6dde15e5d5f2dc75b5dfa55f450b5b682bbb1274564bcb41", size = 12237978, upload-time = "2026-04-08T18:48:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fd/e5637a682cb0af3b9e79017b98b8db5f4bf65c24d9e9fea10dec2495ca13/memray-1.19.3-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:1c7474aa70145eb2be1479b5465022d41a01467dbe4f8487d4fb4c3d38fd6ba9", size = 2184361, upload-time = "2026-04-08T18:48:18.775Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/fcd190a9de788363856d475b595b8a831fefc5c0ee282d27e849dda57d1c/memray-1.19.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ee7f3f0e3f7ee4f5c82692f886ffbabddc885bc9ab3a507732a1aa2155e16ed1", size = 2162568, upload-time = "2026-04-08T18:48:20.691Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/72d70d93f911974652e19f50024142ca674cb19d4f34a91cb2b2b3e065af/memray-1.19.3-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:c1842b2a0033ca44d11c40c9afd5b6a8a29f00e53ea151da4bb81f6dfd194b79", size = 9743474, upload-time = "2026-04-08T18:48:22.544Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ed/d2390f02d978e31666f2821574940f553f27fd1cf38003b592038441a9b8/memray-1.19.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51bea540d8a79c83720bc74d5f9508911572dd77b5fb0fc46d2fe287d96a2dc7", size = 10012845, upload-time = "2026-04-08T18:48:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0f/78eb8d0973e11d0780fabbd048cab184bd4f28788f211d6d7eb97aed7d04/memray-1.19.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:502b07e65a972c3d47e39b0c9f706189f8b667953f68f80672f0537d2ffd9633", size = 9391464, upload-time = "2026-04-08T18:48:28.192Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b7/e209d3fa09f096d7d4b7dd3be7948cc36879aa1ef75a349cf88a7ad74d00/memray-1.19.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e9dc493402446ff495edaa90c6b587a32ace14e2d4a022051458b535a029cada", size = 12244789, upload-time = "2026-04-08T18:48:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d5/36ae02ef5c55cc9d9febb89fb39b78135eaf76d71458703d91cde401142f/memray-1.19.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f62ca641421c0856b38b95c2bc39bdd1493330a94d526efd817d2135a2c1600b", size = 2186101, upload-time = "2026-04-08T18:48:32.663Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/e2/b08b27e84fff1ea039508baaac252c3facbd3a81930e1a8108fd3db1dfcb/memray-1.19.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4335e51dac85891434de4de603f58be1296c2fa463dbf4075b7230820c2a58b", size = 2164551, upload-time = "2026-04-08T18:48:34.86Z" },
+    { url = "https://files.pythonhosted.org/packages/34/48/3a0422d71f43a361782517f6c0b93bdc32e4b211aaa7290c3038a91f991b/memray-1.19.3-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:03f0e1c3584e19951471413f858b70ecb4f1b5d2e3e4bf0c147c104ac79a8548", size = 9743615, upload-time = "2026-04-08T18:48:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/52/f9ee7911819085e174fe07d1bab27691dc1486be39bded35baebda792069/memray-1.19.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:90e634b79be3c332d0d0ab3e1da6ccce6acd20c5fa847f505230ff49d9450a62", size = 9994310, upload-time = "2026-04-08T18:48:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/64/a1f75b5a105cc325b7719a4ed1690c45e751098d17a45902668fd9e0af67/memray-1.19.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4be4535a98c2c93c3195a769c342da12564c8bfd4f5056c3527d237845fd354", size = 9386965, upload-time = "2026-04-08T18:48:41.849Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ad/01178b4c2f61b1b64995f0de9ada899f91abe4de67db793df7d428834456/memray-1.19.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2e3c6433d246063cc33d1ae25104120643492f0750ed5f7ac660d92aba064da6", size = 12238366, upload-time = "2026-04-08T18:48:44.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/21/8034941ba5aeb9f73e05becc40661af54d548c2047e4058948a3d94acd5d/memray-1.19.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:e034252330961dadfe83ac0f111c9a1d3d8fb8f1358c9b992ed664b6a8b2d2a9", size = 2202163, upload-time = "2026-04-08T18:48:46.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/62/ba34b1cf5a8c89f6f4b24e8471a6e6e011e50a86a0d697407320eeaf5b65/memray-1.19.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6ee43e6132fd457d0865b6a1d0de3acdb220e897625a32a0d609beaebb8abd20", size = 2181584, upload-time = "2026-04-08T18:48:48.516Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f7/901e83b6bf71d968bcfdcd5b081d8c5940ec7b5b9d28d67d5d4027d72529/memray-1.19.3-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:78eacb4e1c1b66cf7c4dd6dd27b0c88fb4598b63f3096e014d0a2b91ab70fb6f", size = 9706760, upload-time = "2026-04-08T18:48:50.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/18/a556d0e93d69786edd5c62b8d71bc04f8454b7655b23351a3d95a6d0bc62/memray-1.19.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7c33442360bba89fd34c4b985cd505abbf2bbec6a40bdfdf50e1981a4afd9625", size = 9958651, upload-time = "2026-04-08T18:48:52.88Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/20/f9fea6a3bb8cbc835567ddf89eb524c6fb4c01130b9a4a2b88e65d0c7aca/memray-1.19.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63868a883a6ca926ed1e9200a0d8f3bedde6e1af2a8d4b6ef0cf85160a3b28cd", size = 9382102, upload-time = "2026-04-08T18:48:55.787Z" },
+    { url = "https://files.pythonhosted.org/packages/41/4a/035e5bdeddbd51a2ba1be53f1fc979268c8ce51640b042db4cbee305849b/memray-1.19.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:96ee0a76e4ca57e2ad48a8eccc28531503029884a791bb3556cc9ddac74e148d", size = 12162201, upload-time = "2026-04-08T18:48:57.952Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0a/fea70ec6e5049ee1b1b588b76308558998609764c4ed5171d3369f0d4e5f/memray-1.19.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:47c3415c1270ed359cce1b1b1d06fa1d7835113def765428cc7f38e64c37b805", size = 2208666, upload-time = "2026-04-08T18:49:00.528Z" },
+    { url = "https://files.pythonhosted.org/packages/88/90/6bee06e8ef06130039e20d9cbd578debafb9d9461da1e35fa4d238aa64d1/memray-1.19.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:40a932162b4c42c846d2de8b2574170fb69b3362c7ffc4ff57539b08d2f6b79c", size = 2189313, upload-time = "2026-04-08T18:49:03.115Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e0/5bcc1f8566f0c0cf7f22ebc56cfd0b7ed371fc1dd06791acdf3fc75b7158/memray-1.19.3-cp38-cp38-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:fc9f873609cbbaef82a91f213a1877ab510e9a96d4e20516726a9d7a981c8117", size = 9819750, upload-time = "2026-04-08T18:49:05.704Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/69/be9741a89a548a1dc9c5b9cd983791f57d148ef5b0dcb2bad795c8c6d94e/memray-1.19.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9dbacee6b6eeb206df361f4a9b2d276668bc375a86e390057c4c44db6a534125", size = 10073535, upload-time = "2026-04-08T18:49:11.625Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/85/f15d8b1f9f4347a61a69152a809b100a6bdf0bd5d8b092adef6d7c95c73c/memray-1.19.3-cp38-cp38-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846642b5dd89a09e9ca730f9a100b3a336f375d1b88e35b9f2a192767c89effd", size = 9464322, upload-time = "2026-04-08T18:49:14.016Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c8/a7de0246110d4ed573321e918ec289619b7d79d580fd0738c7591dd61ceb/memray-1.19.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:1628ffd3adf8f1168a04e7e1112151d8ff56366d49e649fbb1521b201e26e18e", size = 12308160, upload-time = "2026-04-08T18:49:16.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f7/4d48d126da8a44d1676e7281ed29debf21d928e13f8cc1d4bb3c4e372477/memray-1.19.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:7f7d688d490d03e61117ab4b6a3c7e1a4e2e71fa6e921f2e0d1ca2c3433bf47d", size = 2184660, upload-time = "2026-04-08T18:49:19.255Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c6/d7d4ae1278b552b491800ab7e93778513b8fcb9ae78ba303156798e49678/memray-1.19.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c4427e68d64feb567e9529f80fa29e469ddfcd576695e1300df441bf06fa75c4", size = 2161947, upload-time = "2026-04-08T18:49:20.98Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/b4/abc91d83f2f822c92ff7b176313ad9b4b2b8a47887f80b05b4a594942c4f/memray-1.19.3-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:203d531fe7c3589f30b3e517bd34ba88bf870ec41ef5d78fc5ea0a003e276765", size = 9717895, upload-time = "2026-04-08T18:49:22.756Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dd/0996843ec27f58dfec5c79b9647cb9e86fdb637be24669ba8bc59af79a35/memray-1.19.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:990620fa28a5fcea3261bdebad6cc8eabefbdac6ae2787f22e83029cbe2c2174", size = 9943250, upload-time = "2026-04-08T18:49:25.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/64/f31a764bd0d4fc1c3512d62da7d4e83379fa73cb16a0c5e5cc0ef2b20eac/memray-1.19.3-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:539e79e326ff59f075ccc5ee3ab3106f0f8e2f9c6cf7806a2af36b29df60ce19", size = 9338315, upload-time = "2026-04-08T18:49:27.908Z" },
+    { url = "https://files.pythonhosted.org/packages/62/18/88d2fae5952436feff47665915edbb6804f44ccb7d39e2335115e7fa4e3f/memray-1.19.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:e48fd857ff8744771a9ddc39ea971db559c3b4d07b4d7f84323f9efe6142f500", size = 12170837, upload-time = "2026-04-08T18:49:30.222Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302, upload-time = "2024-09-17T19:06:50.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439, upload-time = "2024-09-17T19:06:49.212Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1477,6 +1845,41 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pygments", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1557,6 +1960,66 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "textual"
+version = "0.73.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["linkify", "plugins"], marker = "python_full_version < '3.8.1'" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e9/4939bf72d4a7d1a37aa5d55ad4438594a9d5e59875195dd89e9d8c14a9a9/textual-0.73.0.tar.gz", hash = "sha256:ccd1e873370577f557dfdf2b3411f2a4f68b57d4365f9d83a00d084afb15f5a6", size = 1291992, upload-time = "2024-07-18T15:42:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f3/62ec72b437647787ac7305699e7e00318fd25827212a6b5b7fbb278ec17d/textual-0.73.0-py3-none-any.whl", hash = "sha256:4d93d80d203f7fb7ba51828a546e8777019700d529a1b405ceee313dea2edfc2", size = 564394, upload-time = "2024-07-18T15:42:52.883Z" },
+]
+
+[[package]]
+name = "textual"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["linkify", "plugins"], marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+    { name = "platformdirs", version = "4.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+    { name = "pygments", marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/30/38b615f7d4b16f6fdd73e4dcd8913e2d880bbb655e68a076e3d91181a7ee/textual-6.2.1.tar.gz", hash = "sha256:4699d8dfae43503b9c417bd2a6fb0da1c89e323fe91c4baa012f9298acaa83e1", size = 1570645, upload-time = "2025-10-01T16:11:24.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/93/02c7adec57a594af28388d85da9972703a4af94ae1399542555cd9581952/textual-6.2.1-py3-none-any.whl", hash = "sha256:3c7190633cd4d8bfe6049ae66808b98da91ded2edb85cef54e82bf77b03d2a54", size = 710702, upload-time = "2025-10-01T16:11:22.161Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["linkify"], marker = "python_full_version == '3.9.*'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["linkify"], marker = "python_full_version >= '3.10'" },
+    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "mdit-py-plugins", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.9'" },
+    { name = "rich", version = "15.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/1e/1eedc5bac184d00aaa5f9a99095f7e266af3ec46fa926c1051be5d358da1/textual-8.2.5.tar.gz", hash = "sha256:6c894e65a879dadb4f6cf46ddcfedb0173ff7e0cb1fe605ff7b357a597bdbc90", size = 1851596, upload-time = "2026-04-30T08:02:58.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/01/c4555f9c8a692ff83d84930150540f743ce94c89234f9e9a15ff4baba3a8/textual-8.2.5-py3-none-any.whl", hash = "sha256:247d2aa2faf222749c321f88a736247f37ee2c023604079c7490bfacddfcd4b2", size = 727050, upload-time = "2026-04-30T08:03:01.421Z" },
 ]
 
 [[package]]
@@ -1673,6 +2136,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
添加了新的`MemoryProfilerMiddleware`，提供HTTP控制平面用于驱动 Python 标准库的`tracemalloc`和可选的`memray`进行内存分析。包括启动、停止、快照等完整生命周期管理，以及自动优雅关闭处理。同时更新了相关示例和文档。

Co-developed-by: Aone Copilot <noreply@alibaba-inc.com>